### PR TITLE
Add dark layout shell components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,12 @@
+import React from "react";
+import LayoutWrapper from "./components/LayoutWrapper";
+
 export default function App() {
   return (
-    <main className="min-h-screen bg-neutral-950 text-white flex items-center justify-center">
-      <h1 className="text-2xl font-semibold">Keystone Notary Group</h1>
-    </main>
+    <LayoutWrapper>
+      <section className="flex items-center justify-center py-12">
+        <h1 className="text-2xl font-semibold">Welcome to Keystone Notary Group</h1>
+      </section>
+    </LayoutWrapper>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="bg-neutral-950 text-neutral-400">
+      <div className="mx-auto px-4 py-4 text-center sm:px-6 lg:px-8">
+        <p className="text-sm">&copy; {year} Keystone Notary Group. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export default function Header() {
+  return (
+    <header className="bg-neutral-950 text-white">
+      <div className="mx-auto flex items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <h1 className="text-lg font-semibold">Keystone Notary Group</h1>
+        <button
+          type="button"
+          aria-label="Open navigation menu"
+          className="sm:hidden focus:outline-none focus:ring-2 focus:ring-white"
+        >
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import Header from "./Header";
+import Footer from "./Footer";
+
+export default function LayoutWrapper({ children }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-950 text-white">
+      <Header />
+      <main role="main" className="flex-grow">
+        {children}
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add responsive `Header` with hamburger menu
- add `Footer` with automatic year
- add `LayoutWrapper` to combine header, main, and footer
- update `App.js` to use new layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685ce428591083278e10ac5274fd42f5