### PR TITLE
Add services section

### DIFF
--- a/src/components/ServiceCard.jsx
+++ b/src/components/ServiceCard.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function ServiceCard({ title, description }) {
+  return (
+    <div className="rounded-lg bg-neutral-900 p-6 text-white shadow-sm border border-neutral-800">
+      <h3 className="text-xl font-semibold">{title}</h3>
+      <p className="mt-2 text-neutral-300">{description}</p>
+    </div>
+  );
+}

--- a/src/components/ServicesSection.jsx
+++ b/src/components/ServicesSection.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import ServiceCard from "./ServiceCard";
+
+export default function ServicesSection() {
+  return (
+    <section aria-label="Our Services" className="bg-neutral-950 py-12 text-white">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <h2 className="text-center text-2xl font-bold sm:text-3xl">Our Services</h2>
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <ServiceCard
+            title="General Notary Work"
+            description="Acknowledgements, jurats, oaths, affirmations, and more."
+          />
+          <ServiceCard
+            title="Loan Signing Agent"
+            description="Specialized in real estate closings and loan document notarizations."
+          />
+          <ServiceCard
+            title="Remote Online Notary (RON)"
+            description="Secure notarization via video call, anywhere in Pennsylvania."
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import LayoutWrapper from "../components/LayoutWrapper";
 import HeroSection from "../components/HeroSection";
+import ServicesSection from "../components/ServicesSection";
 
 export default function HomePage() {
   return (
     <LayoutWrapper>
       <HeroSection />
+      <ServicesSection />
     </LayoutWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- build ServiceCard component for individual service details
- build ServicesSection to display three services
- display ServicesSection on homepage below HeroSection

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685cebc6f4088327b9b9c4709f91272c