### PR TITLE
Redesign site with premium abstract style

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,10 +2,10 @@ import React from "react";
 
 export default function Footer() {
   return (
-    <footer className="bg-neutral-950/80 text-neutral-400">
-      <div className="mx-auto px-6 py-4 text-center sm:px-8">
+    <footer className="bg-neutral-900 text-gray-500">
+      <div className="mx-auto px-4 py-3 text-center">
         {/* Static copyright text for legal clarity */}
-        <p className="text-sm font-light tracking-wide">&copy; Keystone Notary Group. All rights reserved.</p>
+        <p className="text-xs tracking-wider">&copy; Keystone Notary Group. All rights reserved.</p>
       </div>
     </footer>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,25 +2,15 @@ import React from "react";
 
 export default function Header() {
   return (
-    <header className="bg-neutral-950/80 backdrop-blur text-gray-200">
-      <div className="mx-auto flex items-center justify-between px-6 py-4 sm:px-8">
-        <h1 className="text-lg font-light tracking-wide">Keystone Notary Group</h1>
-        {/* Hamburger icon for mobile navigation */}
+    <header className="bg-neutral-900/80 backdrop-blur border-b border-gray-800 shadow-sm text-gray-200">
+      <div className="mx-auto flex items-center justify-between px-6 py-3 sm:px-8">
+        <h1 className="text-sm uppercase tracking-widest text-gray-100">Keystone Notary Group</h1>
         <button
           type="button"
           aria-label="Open navigation menu"
-          className="sm:hidden focus:outline-none focus:ring-2 focus:ring-white"
+          className="sm:hidden px-3 py-1 text-xs uppercase tracking-wider text-gray-200 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-600"
         >
-          <svg
-            className="h-6 w-6"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
+          Menu
         </button>
       </div>
     </header>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -4,18 +4,19 @@ export default function HeroSection() {
   return (
     <section
       aria-label="Hero Section"
-      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-neutral-950 text-gray-200 before:absolute before:inset-0 before:-z-10 before:bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.15),transparent)] before:blur-2xl"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-gray-900 to-black text-gray-200"
     >
-      <div className="mx-auto max-w-2xl rounded-xl bg-neutral-800/30 px-6 py-12 text-center backdrop-blur-md ring-1 ring-white/10">
-        <h2 className="text-3xl font-bold sm:text-5xl">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.1),transparent)]" />
+      <div className="mx-auto max-w-2xl px-6 py-12 text-center backdrop-blur-md ring-1 ring-white/10 bg-neutral-800/20 shadow-lg">
+        <h2 className="text-4xl font-semibold tracking-wide uppercase">
           Mobile Notary Services in Pennsylvania
         </h2>
-        <p className="mt-4 text-lg text-neutral-300 sm:text-xl">
+        <p className="mt-6 text-lg text-neutral-300">
           Trusted. Insured. Available when you need us.
         </p>
         <button
           type="button"
-          className="mt-8 rounded-md bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus-visible:ring focus-visible:ring-blue-400 focus-visible:ring-opacity-50"
+          className="mt-8 bg-blue-600 px-6 py-3 font-semibold uppercase tracking-wide text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
         >
           Request a Signing
         </button>

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -5,7 +5,7 @@ import Footer from "./Footer";
 export default function LayoutWrapper({ children }) {
   return (
     <div
-      className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-b from-neutral-900 via-neutral-950 to-black text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:40px_40px]"
+      className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-b from-gray-900 to-black text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
     >
       <Header />
       <main role="main" className="flex-grow">

--- a/src/components/ServiceCard.jsx
+++ b/src/components/ServiceCard.jsx
@@ -2,9 +2,9 @@ import React from "react";
 
 export default function ServiceCard({ title, description }) {
   return (
-    <div className="rounded-xl bg-white/5 px-6 py-8 text-gray-200 shadow-lg ring-1 ring-white/10 backdrop-blur transition hover:bg-white/10">
-      <h3 className="text-xl font-semibold tracking-wide">{title}</h3>
-      <p className="mt-2 font-light text-neutral-300">{description}</p>
+    <div className="bg-white/5 px-6 py-6 text-gray-200 shadow-sm ring-1 ring-white/10 border-l-2 border-blue-600">
+      <h3 className="text-xl tracking-wide text-white">{title}</h3>
+      <p className="mt-2 text-neutral-300">{description}</p>
     </div>
   );
 }

--- a/src/components/ServicesSection.jsx
+++ b/src/components/ServicesSection.jsx
@@ -3,10 +3,10 @@ import ServiceCard from "./ServiceCard";
 
 export default function ServicesSection() {
   return (
-    <section aria-label="Our Services" className="bg-gradient-to-b from-neutral-950 via-neutral-900 to-neutral-950 py-16 text-gray-200">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-        <h2 className="text-center text-2xl font-bold tracking-wide sm:text-3xl">Our Services</h2>
-        <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+    <section aria-label="Our Services" className="bg-neutral-900 py-16 text-gray-200">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        <h2 className="text-center text-2xl uppercase tracking-wider">Our Services</h2>
+        <div className="mt-10 space-y-8">
           <ServiceCard
             title="General Notary Work"
             description="Acknowledgements, jurats, oaths, affirmations, and more."


### PR DESCRIPTION
## Summary
- apply geometric gradient background to LayoutWrapper
- sharpen Header with uppercase branding and minimal Menu button
- add layered depth in HeroSection and squared CTA button
- simplify ServicesSection layout and styling
- style ServiceCard with left border and no rounding
- slim down Footer typography

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685cf0051f488327997545100c6cb498