### PR TITLE
Update hero design with background and logo

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -4,23 +4,42 @@ export default function HeroSection() {
   return (
     <section
       aria-label="Hero Section"
-      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-gray-900 to-black text-gray-200"
+      className="relative flex min-h-screen flex-col items-center justify-center text-center bg-cover bg-center text-gray-200"
+      style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
-      <div className="absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.1),transparent)]" />
-      <div className="mx-auto max-w-2xl px-6 py-12 text-center backdrop-blur-md ring-1 ring-white/10 bg-neutral-800/20 shadow-lg">
-        <h2 className="text-4xl font-semibold tracking-wide uppercase">
-          Mobile Notary Services in Pennsylvania
-        </h2>
-        <p className="mt-6 text-lg text-neutral-300">
-          Trusted. Insured. Available when you need us.
-        </p>
-        <button
-          type="button"
-          className="mt-8 bg-blue-600 px-6 py-3 font-semibold uppercase tracking-wide text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
-        >
-          Request a Signing
-        </button>
-      </div>
+      {/* Dark overlay for better contrast */}
+      <div className="absolute inset-0 -z-10 bg-black/60" aria-hidden="true" />
+
+      <img
+        src="/logo.PNG"
+        alt="Keystone Notary Group logo"
+        className="w-48 md:w-64"
+      />
+      <p className="mt-6 text-xl font-light">
+        Mobile Notary Services • Pennsylvania
+      </p>
+
+      <nav aria-label="Main" className="mt-8 space-x-4 text-sm uppercase">
+        <a href="#" className="hover:underline">
+          Home
+        </a>
+        <span aria-hidden="true">&bull;</span>
+        <a href="#" className="hover:underline">
+          About
+        </a>
+        <span aria-hidden="true">&bull;</span>
+        <a href="#" className="hover:underline">
+          Services
+        </a>
+        <span aria-hidden="true">&bull;</span>
+        <a href="#" className="hover:underline">
+          FAQ
+        </a>
+        <span aria-hidden="true">&bull;</span>
+        <a href="#" className="hover:underline">
+          Contact
+        </a>
+      </nav>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- adjust homepage hero section to use **bg-texture.PNG** and centered logo
- add tagline and navigation links

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685d0b7135f4832785d3efa8fba26d3c