### PR TITLE
Add services page with router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
@@ -3079,6 +3080,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13768,6 +13778,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16173,9 +16215,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16183,7 +16225,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,24 @@
   "dependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "tailwindcss": "^3.0.0",
+    "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0"
+    "tailwindcss": "^3.0.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,15 @@
 import React from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomePage from "./pages/index";
+import ServicesPage from "./pages/services";
 
 export default function App() {
-  return <HomePage />;
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/services" element={<ServicesPage />} />
+      </Routes>
+    </Router>
+  );
 }

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export default function HeroSection() {
   return (
@@ -28,9 +29,9 @@ export default function HeroSection() {
           About
         </a>
         <span aria-hidden="true">&bull;</span>
-        <a href="#" className="hover:underline">
+        <Link to="/services" className="hover:underline">
           Services
-        </a>
+        </Link>
         <span aria-hidden="true">&bull;</span>
         <a href="#" className="hover:underline">
           FAQ

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import LayoutWrapper from "../components/LayoutWrapper";
+
+export default function ServicesPage() {
+  return (
+    <LayoutWrapper>
+      <section aria-label="Services" className="mx-auto max-w-2xl px-4 py-20 text-gray-200">
+        <h1 className="mb-12 text-center text-3xl font-semibold">Our Services</h1>
+        <div className="space-y-8">
+          <div className="rounded bg-neutral-800 p-6 shadow-sm">
+            <h2 className="text-xl font-semibold">General Notary Work</h2>
+            <p className="mt-2 text-gray-400">
+              Acknowledgements, jurats, oaths, affirmations, and more.
+            </p>
+          </div>
+          <div className="rounded bg-neutral-800 p-6 shadow-sm">
+            <h2 className="text-xl font-semibold">Loan Signing Agent</h2>
+            <p className="mt-2 text-gray-400">
+              Specialized in real estate closings and loan document notarizations.
+            </p>
+          </div>
+        </div>
+      </section>
+    </LayoutWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- add React Router for page routing
- create `/services` page layout
- link Services navigation button to new page
- update dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d11bb8f688327a6bfb20d63886a8e