### PR TITLE
Improve layout and navigation polish

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,13 +2,15 @@ import React from "react";
 
 export default function Header() {
   return (
-    <header className="bg-neutral-900/80 backdrop-blur border-b border-gray-800 shadow-sm text-gray-200">
-      <div className="mx-auto flex items-center justify-between px-6 py-3 sm:px-8">
-        <h1 className="text-sm uppercase tracking-widest text-gray-100">Keystone Notary Group</h1>
+    <header className="border-b border-gray-800 bg-neutral-900/80 backdrop-blur text-gray-200 shadow-sm">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
+        <h1 className="text-base font-semibold uppercase tracking-wide text-gray-100">
+          Keystone Notary Group
+        </h1>
         <button
           type="button"
           aria-label="Open navigation menu"
-          className="sm:hidden px-3 py-1 text-xs uppercase tracking-wider text-gray-200 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          className="rounded border border-gray-600 px-3 py-1 text-xs uppercase tracking-wide text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-600 sm:hidden"
         >
           Menu
         </button>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -5,7 +5,7 @@ export default function HeroSection() {
   return (
     <section
       aria-label="Hero Section"
-      className="relative flex min-h-screen flex-col items-center justify-center text-center bg-cover bg-center text-gray-200"
+      className="relative flex min-h-screen flex-col items-center justify-center bg-cover bg-center px-4 text-center text-gray-200"
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
       {/* Dark overlay for better contrast */}
@@ -14,32 +14,46 @@ export default function HeroSection() {
       <img
         src="/logo.PNG"
         alt="Keystone Notary Group logo"
-        className="w-48 md:w-64"
+        className="w-48 md:w-60"
       />
-      <p className="mt-6 text-xl font-light">
+      <p className="mt-6 text-lg font-light tracking-wide md:text-xl">
         Mobile Notary Services • Pennsylvania
       </p>
 
-      <nav aria-label="Main" className="mt-8 space-x-4 text-sm uppercase">
-        <a href="#" className="hover:underline">
+      <nav
+        aria-label="Main navigation"
+        className="mt-10 flex flex-wrap justify-center gap-6 text-sm font-medium uppercase"
+      >
+        <Link
+          to="/"
+          className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+        >
           Home
-        </a>
-        <span aria-hidden="true">&bull;</span>
-        <a href="#" className="hover:underline">
+        </Link>
+        <Link
+          to="/about"
+          className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+        >
           About
-        </a>
-        <span aria-hidden="true">&bull;</span>
-        <Link to="/services" className="hover:underline">
+        </Link>
+        <Link
+          to="/services"
+          className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+        >
           Services
         </Link>
-        <span aria-hidden="true">&bull;</span>
-        <a href="#" className="hover:underline">
+        <Link
+          to="/faq"
+          className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+        >
           FAQ
-        </a>
-        <span aria-hidden="true">&bull;</span>
-        <a href="#" className="hover:underline">
+        </Link>
+        <Link
+          to="/contact"
+          className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+        >
           Contact
-        </a>
+        </Link>
       </nav>
     </section>
   );

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -8,7 +8,7 @@ export default function LayoutWrapper({ children }) {
       className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-b from-gray-900 to-black text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
     >
       <Header />
-      <main role="main" className="flex-grow">
+      <main role="main" className="flex-grow px-4 sm:px-6">
         {children}
       </main>
       <Footer />

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -4,8 +4,13 @@ import LayoutWrapper from "../components/LayoutWrapper";
 export default function ServicesPage() {
   return (
     <LayoutWrapper>
-      <section aria-label="Services" className="mx-auto max-w-2xl px-4 py-20 text-gray-200">
-        <h1 className="mb-12 text-center text-3xl font-semibold">Our Services</h1>
+      <section
+        aria-label="Services"
+        className="mx-auto max-w-3xl px-4 py-16 text-gray-200 sm:py-24"
+      >
+        <h1 className="mb-10 text-center text-3xl font-semibold tracking-wide">
+          Our Services
+        </h1>
         <div className="space-y-8">
           <div className="rounded bg-neutral-800 p-6 shadow-sm">
             <h2 className="text-xl font-semibold">General Notary Work</h2>


### PR DESCRIPTION
## Summary
- tweak header spacing and typography
- center hero content and update navigation
- improve services page layout
- add global padding to main content

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685d170710f48327a1f809494b1c9270