### PR TITLE
Fix mobile background coverage

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -5,8 +5,7 @@ export default function HeroSection() {
   return (
     <section
       aria-label="Hero Section"
-      className="relative flex min-h-screen flex-col items-center justify-center bg-cover bg-center bg-no-repeat px-4 text-center text-gray-200"
-      style={{ backgroundImage: "url('/bg-texture.PNG')" }}
+      className="relative flex min-h-screen flex-col items-center justify-center px-4 text-center text-gray-200"
     >
       {/* Dark overlay for better contrast */}
       <div className="absolute inset-0 -z-10 bg-black/60" aria-hidden="true" />

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -5,7 +5,8 @@ import Footer from "./Footer";
 export default function LayoutWrapper({ children }) {
   return (
     <div
-      className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-b from-gray-900 to-black text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
+      className="relative flex min-h-screen w-full flex-col overflow-hidden bg-cover bg-center bg-no-repeat bg-gradient-to-b from-gray-900 to-black text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
+      style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
       <Header />
       <main role="main" className="flex-grow px-4 sm:px-6">


### PR DESCRIPTION
## Summary
- ensure the background image spans the full viewport by applying it to the `LayoutWrapper` container
- remove redundant background styles from `HeroSection`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d29bd4f948327a568e7ac5d839d44