### PR TITLE
Fix navigation layout on hero section

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -21,7 +21,7 @@ export default function HeroSection() {
 
       <nav
         aria-label="Main navigation"
-        className="mt-6 flex flex-col items-center space-y-3 text-sm font-medium uppercase sm:flex-row sm:space-y-0 sm:space-x-6"
+        className="mt-6 flex justify-center gap-6 flex-wrap text-sm font-medium uppercase"
       >
         <Link
           to="/"


### PR DESCRIPTION
## Summary
- keep hero nav horizontal on all screen sizes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d2d1c6a1c8327b60ddad38c5a206a