### PR TITLE
Add About page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomePage from "./pages/index";
 import ServicesPage from "./pages/services";
 import ContactPage from "./pages/contact";
+import AboutPage from "./pages/about";
 
 export default function App() {
   return (
@@ -10,6 +11,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/services" element={<ServicesPage />} />
+        <Route path="/about" element={<AboutPage />} />
         <Route path="/contact" element={<ContactPage />} />
       </Routes>
     </Router>

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import LayoutWrapper from "../components/LayoutWrapper";
+
+export default function AboutPage() {
+  return (
+    <LayoutWrapper>
+      <section
+        aria-label="About"
+        className="mx-auto max-w-3xl px-4 py-16 text-gray-200 sm:py-24"
+      >
+        <h1 className="mb-6 text-center text-2xl font-semibold tracking-wide sm:mb-10 sm:text-3xl">
+          About Keystone Notary Group
+        </h1>
+        <p className="mx-auto max-w-prose text-center text-gray-300">
+          Keystone Notary Group, LLC is a mobile notary service dedicated to professionalism,
+          punctuality, and privacy. We provide document notarization services throughout Bucks
+          and Montgomery County, Pennsylvania.
+        </p>
+        <div className="mt-12 grid gap-6 sm:grid-cols-2">
+          <div className="rounded bg-neutral-800 p-6 text-center shadow-sm">
+            <p className="font-medium">Certified Loan Signing Agent</p>
+          </div>
+          <div className="rounded bg-neutral-800 p-6 text-center shadow-sm">
+            <p className="font-medium">NNA Certified and Insured</p>
+          </div>
+          <div className="rounded bg-neutral-800 p-6 text-center shadow-sm">
+            <p className="font-medium">Serving Bucks & Montgomery County</p>
+          </div>
+          <div className="rounded bg-neutral-800 p-6 text-center shadow-sm">
+            <p className="font-medium">After-Hours & Emergency Services Available</p>
+          </div>
+        </div>
+        <p className="mt-12 text-center text-sm text-gray-400">
+          Commissioned in the Commonwealth of Pennsylvania
+        </p>
+      </section>
+    </LayoutWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- add new /about page with background styling
- wire up route for the about page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d30cebd0c83278a7184d8e317455e