### PR TITLE
Refine homepage logo shadow

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -13,7 +13,7 @@ export default function HeroSection() {
       <img
         src="/logo.PNG"
         alt="Keystone Notary Group logo"
-        className="w-48 md:w-64 shadow-xl shadow-black/50 ring-1 ring-white/10 rounded-sm"
+        className="w-48 md:w-64 shadow-lg shadow-black/60"
       />
       <p className="mt-6 text-base font-light tracking-wide sm:text-lg md:text-xl">
         Mobile Notary Services • Pennsylvania


### PR DESCRIPTION
## Summary
- refine drop shadow for the homepage logo so it doesn't show an outline

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d4bf3ca208327aa2f9e190b761b64