### PR TITLE
Fix CRA build path and document Node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a small React site styled with Tailwind CSS.
 
+## Requirements
+
+- Node.js 18 or later
+
 ## Getting Started
 
 1. Install dependencies: `npm install`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -5,7 +5,8 @@ import Footer from "./Footer";
 export default function LayoutWrapper({ children }) {
   return (
     <div
-      className="relative flex min-h-screen w-full flex-col overflow-hidden bg-cover bg-center bg-no-repeat bg-[url('/bg-texture.PNG')] brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
+      className="relative flex min-h-screen w-full flex-col overflow-hidden bg-cover bg-center bg-no-repeat brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
+      style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
       <Header />
       <main role="main" className="flex-grow px-4 py-8 sm:px-6 sm:py-12">


### PR DESCRIPTION
## Summary
- fix background image path so build works
- specify Node 18+ for deployment
- document Node requirement in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d5491a778832789d51156edf8def7