### PR TITLE
Improve page spacing and alignment

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function Footer() {
   return (
     <footer className="bg-neutral-900 text-gray-500">
-      <div className="mx-auto px-4 py-3 text-center">
+      <div className="mx-auto max-w-screen-lg px-4 py-3 text-center sm:px-6 lg:px-8">
         {/* Static copyright text for legal clarity */}
         <p className="text-xs tracking-wider">&copy; Keystone Notary Group. All rights reserved.</p>
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,8 +3,12 @@ import React from "react";
 export default function Header() {
   return (
     <header className="border-b border-gray-800 bg-neutral-900/80 backdrop-blur text-gray-200 shadow-sm">
-      <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between px-4 py-2 sm:flex-nowrap sm:px-6 sm:py-3">
-        <h1 className="text-sm font-semibold uppercase tracking-wide text-gray-100 sm:text-base">
+      <div
+        className="mx-auto flex max-w-screen-lg items-center justify-between px-4 py-3 sm:px-6 lg:px-8"
+      >
+        <h1
+          className="flex-1 text-center text-sm font-semibold uppercase tracking-wide text-gray-100 sm:text-left sm:text-base"
+        >
           Keystone Notary Group
         </h1>
         {/* Navigation drawer trigger - functionality handled elsewhere */}

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -5,22 +5,22 @@ export default function LandingHero() {
   return (
     <section
       aria-label="Landing Hero"
-      className="relative flex min-h-screen w-full flex-col items-center justify-center bg-cover bg-center bg-no-repeat px-4 text-center text-gray-200 filter brightness-125"
+      className="relative flex min-h-screen w-full flex-col items-center justify-center bg-cover bg-center bg-no-repeat px-4 text-center text-gray-200 filter brightness-125 sm:px-6 lg:px-8"
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
-      <div className="p-6">
+      <div className="p-6 sm:p-8">
         <img
           src="/logo.PNG"
           alt="Keystone Notary Group logo"
           className="mx-auto w-40 sm:w-52 md:w-64 bg-transparent"
         />
-        <p className="mt-6 text-base font-light tracking-wide sm:text-lg md:text-xl">
+        <p className="mt-4 text-base font-light tracking-wide sm:mt-6 sm:text-lg md:text-xl">
           Mobile Notary Services • Pennsylvania
         </p>
 
         <nav
           aria-label="Main navigation"
-          className="mt-6 flex justify-center gap-6 flex-wrap text-sm font-medium uppercase"
+          className="mt-6 flex flex-wrap justify-center gap-x-6 gap-y-3 text-sm font-medium uppercase"
         >
           <Link
             to="/"

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -9,7 +9,10 @@ export default function LayoutWrapper({ children }) {
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
       <Header />
-      <main role="main" className="flex-grow px-4 py-8 sm:px-6 sm:py-12">
+      <main
+        role="main"
+        className="mx-auto flex-grow max-w-screen-lg px-4 py-12 sm:px-6 sm:py-16 lg:px-8"
+      >
         {children}
       </main>
       <Footer />

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -6,9 +6,9 @@ export default function AboutPage() {
     <LayoutWrapper>
       <section
         aria-label="About"
-        className="mx-auto max-w-3xl px-4 py-16 text-gray-200 sm:py-24"
+        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
-        <h1 className="mb-6 text-center text-2xl font-semibold tracking-wide sm:mb-10 sm:text-3xl">
+        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           About Keystone Notary Group
         </h1>
         <p className="mx-auto max-w-prose text-center text-gray-300">
@@ -16,7 +16,7 @@ export default function AboutPage() {
           punctuality, and privacy. We provide document notarization services throughout Bucks
           and Montgomery County, Pennsylvania.
         </p>
-        <div className="mt-12 grid gap-6 sm:grid-cols-2">
+        <div className="mt-10 grid gap-6 sm:mt-12 sm:grid-cols-2">
           <div className="rounded bg-neutral-800 p-6 text-center shadow-sm">
             <p className="font-medium">Certified Loan Signing Agent</p>
           </div>

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -11,9 +11,9 @@ export default function ContactPage() {
     <LayoutWrapper>
       <section
         aria-label="Contact"
-        className="mx-auto max-w-lg px-4 py-16 text-gray-200 sm:py-24"
+        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
-        <h1 className="mb-10 text-center text-2xl font-semibold tracking-wide sm:text-3xl">
+        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Contact
         </h1>
         <form onSubmit={handleSubmit} className="space-y-6 sm:space-y-8">
@@ -63,7 +63,7 @@ export default function ContactPage() {
           </div>
         </form>
         {/* Additional instructions and contact information */}
-        <p className="mt-8 text-sm text-gray-400">
+        <p className="mt-8 text-sm text-gray-400 sm:mt-10">
           Please mention the type of document or notarization service you are requesting.
         </p>
         <div className="mt-6 space-y-2 text-sm text-gray-300">

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -29,12 +29,12 @@ export default function FaqPage() {
     <LayoutWrapper>
       <section
         aria-label="Frequently Asked Questions"
-        className="mx-auto max-w-3xl px-4 py-16 text-gray-200 sm:py-24"
+        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
-        <h1 className="mb-10 text-center text-2xl font-semibold tracking-wide sm:text-3xl">
+        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Frequently Asked Questions
         </h1>
-        <div className="space-y-8">
+        <div className="space-y-6 sm:space-y-8">
           {faqs.map(({ q, a }) => (
             <div key={q} className="rounded bg-neutral-800 p-6 shadow-sm">
               <h2 className="text-lg font-medium text-gray-100">{q}</h2>

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -6,9 +6,9 @@ export default function ServicesPage() {
     <LayoutWrapper>
       <section
         aria-label="Services"
-        className="mx-auto max-w-3xl px-4 py-16 text-gray-200 sm:py-24"
+        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
-        <h1 className="mb-10 text-center text-2xl font-semibold tracking-wide sm:text-3xl">
+        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Our Services
         </h1>
         <div className="space-y-8 sm:space-y-10">


### PR DESCRIPTION
## Summary
- center and space header elements
- tweak hero layout spacing
- constrain main content to max-width container
- tighten layout of about, services, contact, and faq pages
- unify footer container

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d73ebb988832785018c1a28ccfae0