### PR TITLE
Improve landing page centering and mobile layout

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -5,72 +5,79 @@ export default function LandingHero() {
   return (
     <section
       aria-label="Landing Hero"
-      className="relative flex min-h-screen w-full flex-col items-center justify-center bg-cover bg-center bg-no-repeat px-4 text-center text-gray-200 filter brightness-125 sm:px-6 lg:px-8"
-      style={{ backgroundImage: "url('/bg-texture.PNG')" }}
+      className="relative flex min-h-[90vh] w-full items-center justify-center overflow-hidden bg-neutral-900 text-gray-200"
     >
-      <div className="p-6 sm:p-8">
-        <div className="mx-auto max-w-screen-md p-8 sm:p-10">
-          <img
-            src="/logo.PNG"
-            alt="Keystone Notary Group logo"
-            className="mx-auto w-40 bg-transparent sm:w-52 md:w-64"
-          />
-        <p className="mt-4 text-base font-light tracking-wide sm:mt-6 sm:text-lg md:text-xl">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 -z-10 bg-cover bg-center opacity-50"
+        style={{ backgroundImage: "url('/bg-texture.PNG')" }}
+      />
+      <div className="mx-auto w-full max-w-screen-md px-4 py-12 text-center sm:py-16">
+        <img
+          src="/logo.PNG"
+          alt="Keystone Notary Group logo"
+          className="mx-auto w-40 sm:w-52 md:w-64"
+        />
+        <h1 className="mt-4 text-base font-light tracking-wide text-amber-200 sm:mt-6 sm:text-lg md:text-xl">
           Mobile Notary Services • Pennsylvania
-        </p>
+        </h1>
 
-        <nav
-          aria-label="Main navigation"
-          className="mt-8 sm:mt-10"
-        >
-          <ul className="flex items-center justify-center gap-2 text-sm font-medium uppercase sm:gap-3">
+        <nav aria-label="Main navigation" className="mt-8 sm:mt-10">
+          <ul className="flex flex-wrap items-center justify-center gap-3 text-sm font-medium uppercase sm:gap-4">
             <li>
               <Link
                 to="/"
-                className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+                className="text-gray-300 transition-colors hover:text-white focus-visible:text-white"
               >
                 Home
               </Link>
             </li>
-            <li aria-hidden="true" className="select-none text-gray-400">&bull;</li>
+            <li aria-hidden="true" className="hidden select-none text-gray-400 sm:block">
+              &bull;
+            </li>
             <li>
               <Link
                 to="/about"
-                className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+                className="text-gray-300 transition-colors hover:text-white focus-visible:text-white"
               >
                 About
               </Link>
             </li>
-            <li aria-hidden="true" className="select-none text-gray-400">&bull;</li>
+            <li aria-hidden="true" className="hidden select-none text-gray-400 sm:block">
+              &bull;
+            </li>
             <li>
               <Link
                 to="/services"
-                className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+                className="text-gray-300 transition-colors hover:text-white focus-visible:text-white"
               >
                 Services
               </Link>
             </li>
-            <li aria-hidden="true" className="select-none text-gray-400">&bull;</li>
+            <li aria-hidden="true" className="hidden select-none text-gray-400 sm:block">
+              &bull;
+            </li>
             <li>
               <Link
                 to="/faq"
-                className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+                className="text-gray-300 transition-colors hover:text-white focus-visible:text-white"
               >
                 FAQ
               </Link>
             </li>
-            <li aria-hidden="true" className="select-none text-gray-400">&bull;</li>
+            <li aria-hidden="true" className="hidden select-none text-gray-400 sm:block">
+              &bull;
+            </li>
             <li>
               <Link
                 to="/contact"
-                className="text-gray-400 transition-colors hover:text-white focus-visible:text-white"
+                className="text-gray-300 transition-colors hover:text-white focus-visible:text-white"
               >
                 Contact
               </Link>
             </li>
           </ul>
         </nav>
-        </div>
       </div>
     </section>
   );

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Header from "./Header";
 import Footer from "./Footer";
 
-export default function LayoutWrapper({ children }) {
+export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
       className="relative flex min-h-screen w-full flex-col overflow-hidden bg-cover bg-center bg-no-repeat brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
@@ -11,7 +11,11 @@ export default function LayoutWrapper({ children }) {
       <Header />
       <main
         role="main"
-        className="mx-auto flex-grow max-w-screen-lg px-4 py-12 sm:px-6 sm:py-16 lg:px-8"
+        className={`flex-grow ${
+          fullWidth
+            ? ''
+            : 'mx-auto max-w-screen-lg px-4 py-12 sm:px-6 sm:py-16 lg:px-8'
+        }`}
       >
         {children}
       </main>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,7 +4,7 @@ import LandingHero from "../components/LandingHero";
 
 export default function HomePage() {
   return (
-    <LayoutWrapper>
+    <LayoutWrapper fullWidth>
       <LandingHero />
     </LayoutWrapper>
   );


### PR DESCRIPTION
## Summary
- center hero logo and navigation
- add optional `fullWidth` prop to `LayoutWrapper` and apply on the home page
- improve color and spacing of landing page links

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685ee3caffb48327b4fd38f0bfb9c355