### PR TITLE
Set global background image

### DIFF
--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -5,8 +5,7 @@ import Footer from "./Footer";
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
-      className="relative flex min-h-screen w-full flex-col overflow-hidden bg-cover bg-center bg-no-repeat brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
-      style={{ backgroundImage: "url('/bg-texture.PNG')" }}
+      className="relative flex min-h-screen w-full flex-col overflow-hidden brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
     >
       <Header />
       <main

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  /* Global background pattern */
+  body {
+    @apply bg-cover bg-center bg-no-repeat min-h-screen;
+    background-image: url('../public/bg-texture.PNG');
+  }
+}


### PR DESCRIPTION
## Summary
- add a global background pattern using `bg-texture.PNG`
- remove redundant background styling from `LayoutWrapper`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685ee5f5d2dc83279d099eec31b9301d