### PR TITLE
Add NotFound route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import ServicesPage from "./pages/services";
 import ContactPage from "./pages/contact";
 import AboutPage from "./pages/about";
 import FaqPage from "./pages/faq";
+import NotFound from "./pages/NotFound";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/about" element={<AboutPage />} />
         <Route path="/faq" element={<FaqPage />} />
         <Route path="/contact" element={<ContactPage />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </Router>
   );

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import LayoutWrapper from "../components/LayoutWrapper";
+
+export default function NotFound() {
+  return (
+    <LayoutWrapper>
+      <section
+        aria-label="Page not found"
+        className="mx-auto max-w-screen-lg px-4 py-12 text-center text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+      >
+        <h1 className="mb-4 text-2xl font-semibold sm:text-3xl">404 – Page Not Found</h1>
+        <p className="mb-8 text-gray-400">Sorry, the page you are looking for doesn\'t exist.</p>
+        <Link
+          to="/"
+          className="inline-block rounded-md bg-blue-600 px-6 py-2 font-semibold text-white transition-colors hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+        >
+          Return Home
+        </Link>
+      </section>
+    </LayoutWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- create `NotFound` page with link back home
- route unmatched URLs to `NotFound`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685f4f67cf548327a622b9742bc6c799