### PR TITLE
Remove tagline from hero

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -20,10 +20,7 @@ export default function LandingHero() {
           alt="Keystone Notary Group logo"
           className="mx-auto w-40 sm:w-52 md:w-64"
         />
-        <p className="mt-4 text-sm tracking-wide text-amber-200 sm:mt-6 sm:text-base">
-          Mobile Notary Services • Pennsylvania
-        </p>
-        <div className="mt-10 sm:mt-12">
+        <div className="mt-8 sm:mt-10">
           <ul className="flex justify-center gap-x-6 text-sm font-medium uppercase text-gray-300 sm:flex-col sm:gap-x-0 sm:gap-y-2">
             {navItems.map((label) => (
               <li key={label}>


### PR DESCRIPTION
## Summary
- remove tagline text from LandingHero and tweak spacing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_685f656ce5188327a71aff7f0932cabf