### PR TITLE
Improve hero fade-in timing

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -15,7 +15,7 @@ export default function LandingHero() {
       ></div>
 
       <div className="relative z-10 mx-auto w-full max-w-screen-md px-4 py-12 text-center sm:py-16">
-        <div className="opacity-0 transition-opacity duration-700 animate-fadeIn">
+        <div className="opacity-0 transition-opacity duration-1000 animate-fadeIn">
           <img
             src="/logo.PNG"
             alt="Keystone Notary Group logo"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
   theme: {
     extend: {
       animation: {
-        fadeIn: 'fadeIn 1s ease-out forwards',
+        fadeIn: 'fadeIn 1000ms ease-out forwards',
       },
       keyframes: {
         fadeIn: {


### PR DESCRIPTION
## Summary
- update fade-in animation duration to 1000ms in Tailwind config
- adjust LandingHero animation utility duration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f6c9b817c83279ee573a3a3c96ef4