### PR TITLE
Align NNA seal with services section

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -145,7 +145,7 @@ export default function LandingHero() {
           src="/nna-seal.PNG"
           alt=""
           aria-hidden="true"
-          className="absolute bottom-6 right-6 w-24 opacity-60 rotate-[-8deg] pointer-events-none"
+          className="absolute bottom-[-2rem] right-[-1rem] w-20 md:w-24 rotate-[-10deg] z-10 pointer-events-none shadow-xl shadow-black/30"
         />
       </div>
     </section>

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -6,7 +6,7 @@ export default function ServicesPage() {
     <LayoutWrapper>
       <section
         aria-label="Services"
-        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="relative mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
         <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Our Services
@@ -36,6 +36,12 @@ export default function ServicesPage() {
             </li>
           </ul>
         </div>
+        <img
+          src="/nna-seal.PNG"
+          alt=""
+          aria-hidden="true"
+          className="absolute bottom-[-2rem] right-[-1rem] w-20 md:w-24 rotate-[-10deg] z-10 pointer-events-none shadow-xl shadow-black/30"
+        />
       </section>
     </LayoutWrapper>
   );


### PR DESCRIPTION
## Summary
- reposition NNA seal in landing page services section
- add certification seal to Services page

## Testing
- `npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_b_685f92651b4c83279538fd999d617ae7