### PR TITLE
Fix overlapping NNA seal on services page

### DIFF
--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -4,7 +4,8 @@ import LayoutWrapper from "../components/LayoutWrapper";
 export default function ServicesPage() {
   return (
     <LayoutWrapper>
-      <div className="relative w-full pb-48 pr-8">
+      {/* Extra bottom padding keeps the NNA seal from overlapping page text */}
+      <div className="relative w-full pb-64 pr-8">
         <section
           aria-label="Services"
           className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"


### PR DESCRIPTION
## Summary
- expand bottom padding on `services.jsx` so the NNA seal can move further down

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685fcadff2888327be39c590a82f49e4