### PR TITLE
Add subtle parchment overlay for hero

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -30,7 +30,11 @@ export default function LandingHero() {
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40"
-          style={{ backgroundImage: "url('/bg-texture.PNG')" }}
+          /* Faint parchment overlay to subtly reinforce legal theme */
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(246,242,238,0.45), rgba(246,242,238,0.45)), url('/bg-texture.PNG')",
+          }}
           aria-hidden="true"
         ></div>
 


### PR DESCRIPTION
## Summary
- add faint parchment overlay behind hero text to enhance legal feel

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685fd99e8d0083278faadc79eca5e148