### PR TITLE
Add subtle dividers to service lists

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -111,7 +111,8 @@ export default function LandingHero() {
             Our Services
           </h2>
           <div className="space-y-8">
-            <ul className="list-disc list-inside space-y-4 text-left text-lg text-gray-300">
+            {/* Add subtle dividers between list items for improved readability */}
+            <ul className="list-disc list-inside divide-y divide-gray-400/20 space-y-4 text-left text-lg text-gray-300">
               <li>
                 General notary work including acknowledgments, oaths,
                 affirmations, and signature witnessing

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -13,7 +13,8 @@ export default function ServicesPage() {
         </h1>
 
         <div className="space-y-8">
-          <ul className="list-disc list-inside space-y-4 text-left text-lg text-gray-300">
+          {/* Add subtle dividers between list items for improved readability */}
+          <ul className="list-disc list-inside divide-y divide-gray-400/20 space-y-4 text-left text-lg text-gray-300">
             <li>
               General notary work including acknowledgments, oaths,
               affirmations, and signature witnessing


### PR DESCRIPTION
## Summary
- improve readability on the services list by adding subtle dividers between `<li>` items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685fdaff62f08327aeafec9bd4019abf