### PR TITLE
Enhance CTA button style

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -262,7 +262,8 @@ export default function LandingHero() {
             <div className="text-center">
               <button
                 type="submit"
-                className="rounded-md bg-blue-600 px-6 py-2 font-semibold text-white transition hover:bg-blue-500 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+                aria-label="Send Message"
+                className="rounded-md bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-2 font-semibold text-white transition transform hover:scale-105 hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
               >
                 Send Message
               </button>

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -56,7 +56,8 @@ export default function ContactPage() {
           <div className="text-center">
             <button
               type="submit"
-              className="rounded-md bg-blue-600 px-6 py-2 font-semibold text-white transition-colors hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+              aria-label="Send Message"
+              className="rounded-md bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-2 font-semibold text-white transition transform hover:scale-105 hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
             >
               Send Message
             </button>


### PR DESCRIPTION
## Summary
- style "Send Message" button in contact and hero sections with a gradient background
- add aria-label for improved accessibility

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_685fdc45a2ac8327aeb8343a25318931