### PR TITLE
Add certifications section

### DIFF
--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+
+export default function Certifications() {
+  return (
+    <section className="bg-gray-950 text-gray-200 py-12">
+      <div className="mx-auto max-w-screen-lg px-4">
+        <h2 className="mb-8 text-2xl font-semibold text-center">
+          Certifications & Credentials
+        </h2>
+        <ul
+          role="list"
+          className="mx-auto grid max-w-md gap-6 sm:max-w-none sm:grid-cols-2 md:grid-cols-4"
+        >
+          <li className="flex items-center justify-center space-x-3">
+            <svg
+              className="h-6 w-6 flex-shrink-0 text-amber-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z"
+              />
+            </svg>
+            <span>NNA Certified Notary Signing Agent</span>
+          </li>
+          <li className="flex items-center justify-center space-x-3">
+            <svg
+              className="h-6 w-6 flex-shrink-0 text-amber-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+              />
+            </svg>
+            <span>Commissioned Notary Public in Pennsylvania</span>
+          </li>
+          <li className="flex items-center justify-center space-x-3">
+            <svg
+              className="h-6 w-6 flex-shrink-0 text-amber-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"
+              />
+            </svg>
+            <span>Insured &amp; Bonded</span>
+          </li>
+          <li className="flex items-center justify-center space-x-3">
+            <svg
+              className="h-6 w-6 flex-shrink-0 text-amber-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"
+              />
+            </svg>
+            <span>Professional Mobile Services</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import Header from "./Header";
 import Footer from "./Footer";
+import Certifications from "./Certifications";
 
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
@@ -49,6 +50,7 @@ export default function LayoutWrapper({ children, fullWidth = false }) {
       >
         {children}
       </main>
+      <Certifications />
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- create `Certifications` component
- include the new section in `LayoutWrapper` so it appears above the footer
- add trust badges for notary credentials using inline SVG icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68600183b8d08327a036a6b4bf54ec76