### PR TITLE
Show success message on contact form

### DIFF
--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import LayoutWrapper from "../components/LayoutWrapper";
 
 export default function ContactPage() {
+  const [submitted, setSubmitted] = useState(false);
+
   // Prevent default form submission until backend integration is added
   const handleSubmit = (e) => {
     e.preventDefault();
+    // Reset form fields so the user sees a clear form
+    e.target.reset();
+    // Show confirmation message
+    setSubmitted(true);
   };
 
   return (
@@ -63,6 +69,16 @@ export default function ContactPage() {
             </button>
           </div>
         </form>
+        <p
+          role="status"
+          aria-live="polite"
+          className={
+            "text-green-400 text-center mt-6 text-lg font-medium transition-opacity duration-500" +
+            (submitted ? " opacity-100" : " opacity-0")
+          }
+        >
+          ✅ Thank you! Your message has been sent. We’ll be in touch shortly.
+        </p>
         <p className="mt-4 text-left text-sm text-gray-500">
           <strong>Disclaimer:</strong> Keystone Notary Group, LLC is not a law
           firm and does not provide legal advice, guidance on document selection,

--- a/src/pages/contact.test.js
+++ b/src/pages/contact.test.js
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactPage from './contact.jsx';
+
+test('shows confirmation message on successful form submission', () => {
+  render(<ContactPage />);
+  fireEvent.change(screen.getByLabelText(/full name/i), { target: { value: 'John' } });
+  fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } });
+  fireEvent.change(screen.getByLabelText(/^Message$/i), { target: { value: 'Hello' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+  expect(
+    screen.getByText(/thank you! your message has been sent/i)
+  ).toBeInTheDocument();
+
+  expect(screen.getByLabelText(/full name/i).value).toBe('');
+  expect(screen.getByLabelText(/email address/i).value).toBe('');
+  expect(screen.getByLabelText(/^Message$/i).value).toBe('');
+});


### PR DESCRIPTION
## Summary
- show success confirmation for contact form
- reset contact form on submit
- test contact form submission

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686012b0056c8327a20daf2ffcd11145