### PR TITLE
Fix mobile menu stacking order

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -59,7 +59,7 @@ export default function Header() {
         role="presentation"
         aria-hidden={!open}
         aria-label="Menu overlay"
-        className={`sm:hidden fixed inset-0 z-40 bg-black/80 transition-opacity duration-300 ${
+        className={`sm:hidden fixed inset-0 z-[9999] bg-black/80 transition-opacity duration-300 ${
           open ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
         onClick={closeMenu}


### PR DESCRIPTION
## Summary
- ensure mobile nav overlay appears on top of the header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686097fb605c83278bf2e483d1429477