### PR TITLE
Make header sticky with scroll shadow

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,6 +4,7 @@ import { NavLink } from "react-router-dom";
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const firstRef = useRef(null);
   const lastRef = useRef(null);
 
@@ -19,6 +20,16 @@ export default function Header() {
       body.classList.remove("overflow-hidden");
     }
   }, [open]);
+
+  // Toggle a shadow once the user scrolls down the page
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 0);
+    };
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // initialize on mount
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const handleKeyDown = (e) => {
     if (e.key === "Tab") {
@@ -37,7 +48,12 @@ export default function Header() {
   };
 
   return (
-    <header className="border-b border-gray-800 bg-neutral-900/80 backdrop-blur text-gray-200 shadow-sm">
+    <header
+      role="banner"
+      className={`sticky top-0 border-b border-gray-800 bg-neutral-900/80 backdrop-blur text-gray-200 transition-shadow duration-300 ${
+        scrolled ? "shadow-md" : "shadow-none"
+      }`}
+    >
       <div className="mx-auto flex max-w-screen-xl flex-wrap items-center justify-center gap-4 px-4 py-2 sm:flex-nowrap sm:justify-between sm:px-6 sm:py-3">
         <h1 className="text-center text-sm font-semibold uppercase tracking-wide text-gray-100 sm:text-base">
           Keystone Notary Group

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -22,3 +22,20 @@ test('mobile menu opens and closes properly', () => {
   expect(toggle).toHaveAttribute('aria-expanded', 'false');
   expect(document.body).not.toHaveClass('overflow-hidden');
 });
+
+test('adds shadow when page is scrolled', () => {
+  Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: 0 });
+  render(
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>
+  );
+
+  const header = screen.getByRole('banner');
+  expect(header.className).toMatch(/shadow-none/);
+
+  window.scrollY = 100;
+  fireEvent.scroll(window);
+
+  expect(header.className).toMatch(/shadow-md/);
+});


### PR DESCRIPTION
## Summary
- keep the navigation bar visible by making the header sticky
- add a subtle shadow on scroll for visual separation
- test that sticky header behaviour works

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6860b9d4b2188327bd256ae7193b8927