### PR TITLE
Add mobile section separators

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -152,6 +152,11 @@ export default function LandingHero() {
         </div>
       </div>
     </section>
+    {/* Mobile separator between Services and FAQ */}
+    <hr
+      aria-hidden="true"
+      className="border-neutral-800 sm:hidden"
+    />
 
       {/* FAQ Section */}
       <section
@@ -212,6 +217,11 @@ export default function LandingHero() {
           </div>
         </div>
       </section>
+    {/* Mobile separator between FAQ and Contact */}
+    <hr
+      aria-hidden="true"
+      className="border-neutral-800 sm:hidden"
+    />
 
       {/* Contact Section */}
       <section


### PR DESCRIPTION
## Summary
- add `<hr>` separators between Services, FAQ, and Contact sections on the landing page for clarity on small screens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6860d7465d748327be5ecc16c06f266e