### PR TITLE
Add mobile background colors for service sections

### DIFF
--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -17,7 +17,7 @@ export default function ContactPage() {
     <LayoutWrapper>
       <section
         aria-label="Contact"
-        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
         <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Contact

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -29,7 +29,7 @@ export default function FaqPage() {
     <LayoutWrapper>
       <section
         aria-label="Frequently Asked Questions"
-        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="bg-neutral-900 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
         <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Frequently Asked Questions

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -6,7 +6,7 @@ export default function ServicesPage() {
     <LayoutWrapper>
       <section
         aria-label="Services"
-        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >
         <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Our Services


### PR DESCRIPTION
## Summary
- adjust Services, FAQ, and Contact pages to have dedicated background colors for easier section separation on phones

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6860e4f1ae5c83279b3b414a30f7ce6c