### PR TITLE
Keep header visible during scroll

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -50,7 +50,7 @@ export default function Header() {
   return (
     <header
       role="banner"
-      className={`sticky top-0 border-b border-gray-800 bg-neutral-900/80 backdrop-blur text-gray-200 transition-shadow duration-300 ${
+      className={`fixed top-0 left-0 right-0 z-50 border-b border-gray-800 bg-neutral-900/80 backdrop-blur text-gray-200 transition-shadow duration-300 ${
         scrolled ? "shadow-sm" : "shadow-none"
       }`}
     >

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -78,7 +78,7 @@ export default function LayoutWrapper({ children, fullWidth = false }) {
       <Header />
       <main
         role="main"
-        className={`flex-grow pb-20 ${
+        className={`flex-grow pt-20 pb-20 ${
           fullWidth
             ? ''
             : 'mx-auto max-w-screen-lg px-4 py-12 sm:px-6 sm:py-16 lg:px-8'


### PR DESCRIPTION
## Summary
- keep the header bar fixed to the top of the screen
- add padding to page content so it doesn't hide under the header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6860e9fb524083278c8c6e8d0f21f81b