### PR TITLE
Add mobile request notary CTA

### DIFF
--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -4,6 +4,7 @@ import Header from "./Header";
 import Footer from "./Footer";
 import Certifications from "./Certifications";
 import BackToTopButton from "./BackToTopButton";
+import RequestNotaryButton from "./RequestNotaryButton";
 
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
@@ -88,6 +89,8 @@ export default function LayoutWrapper({ children, fullWidth = false }) {
       </main>
       <Certifications />
       <Footer />
+      {/* Floating quick access button for mobile devices */}
+      <RequestNotaryButton />
       <BackToTopButton />
     </div>
   );

--- a/src/components/RequestNotaryButton.jsx
+++ b/src/components/RequestNotaryButton.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * Fixed mobile button that navigates to the contact section.
+ */
+export default function RequestNotaryButton() {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate("/contact#contact");
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="Request Notary"
+      className="sm:hidden fixed bottom-4 left-1/2 z-40 -translate-x-1/2 rounded-full bg-blue-600 px-6 min-h-[48px] py-3 font-semibold text-white shadow-md transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+    >
+      Request Notary
+    </button>
+  );
+}

--- a/src/components/RequestNotaryButton.test.js
+++ b/src/components/RequestNotaryButton.test.js
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RequestNotaryButton from './RequestNotaryButton.jsx';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+test('navigates to contact section when clicked', () => {
+  render(
+    <MemoryRouter>
+      <RequestNotaryButton />
+    </MemoryRouter>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /request notary/i }));
+  expect(mockNavigate).toHaveBeenCalledWith('/contact#contact');
+});


### PR DESCRIPTION
## Summary
- create `RequestNotaryButton` floating button
- include the new button in `LayoutWrapper`
- test navigation for the button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68612381efd88327a7ab891e65e2bf1a