### PR TITLE
Fix Request Notary button on mobile

### DIFF
--- a/src/components/RequestNotaryButton.jsx
+++ b/src/components/RequestNotaryButton.jsx
@@ -1,22 +1,43 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 /**
  * Fixed mobile button that navigates to the contact section.
+ * Hides when form fields are focused to avoid keyboard overlap on iOS Safari.
  */
 export default function RequestNotaryButton() {
   const navigate = useNavigate();
+  const [hidden, setHidden] = useState(false);
 
   const handleClick = () => {
     navigate("/contact#contact");
   };
+
+  useEffect(() => {
+    const focusIn = (e) => {
+      if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
+        setHidden(true);
+      }
+    };
+    const focusOut = (e) => {
+      if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
+        setHidden(false);
+      }
+    };
+    window.addEventListener("focusin", focusIn);
+    window.addEventListener("focusout", focusOut);
+    return () => {
+      window.removeEventListener("focusin", focusIn);
+      window.removeEventListener("focusout", focusOut);
+    };
+  }, []);
 
   return (
     <button
       type="button"
       onClick={handleClick}
       aria-label="Request Notary"
-      className="sm:hidden fixed bottom-4 left-1/2 z-40 -translate-x-1/2 rounded-full bg-blue-600 px-6 min-h-[48px] py-3 font-semibold text-white shadow-md transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+      className={`sm:hidden fixed bottom-0 left-0 right-0 z-50 w-full py-4 bg-blue-600 min-h-[48px] font-semibold text-white shadow-md transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 ${hidden ? "hidden" : ""}`}
     >
       Request Notary
     </button>


### PR DESCRIPTION
## Summary
- ensure Request Notary button is fully visible on mobile
- hide the fixed button when inputs are focused to avoid keyboard overlap

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686125cb1f2083279d4b041e6d686c23