### PR TITLE
Fix mobile Request Notary button

### DIFF
--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -9,7 +9,7 @@ import RequestNotaryButton from "./RequestNotaryButton";
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
-      className="scroll-smooth relative flex min-h-screen w-full flex-col overflow-hidden brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
+      className="scroll-smooth relative flex min-h-screen w-full flex-col overflow-x-hidden brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
       /* Ensure pages share consistent textured background */
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >

--- a/src/components/RequestNotaryButton.jsx
+++ b/src/components/RequestNotaryButton.jsx
@@ -33,13 +33,19 @@ export default function RequestNotaryButton() {
   }, []);
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      aria-label="Request Notary"
-      className={`sm:hidden fixed bottom-0 left-0 right-0 z-50 w-full py-4 bg-blue-600 min-h-[48px] font-semibold text-white shadow-md transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 ${hidden ? "hidden" : ""}`}
+    <div
+      className={`pointer-events-none fixed bottom-4 left-4 right-4 z-50 md:hidden ${
+        hidden ? "hidden" : ""
+      }`}
     >
-      Request Notary
-    </button>
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label="Request Notary"
+        className="pointer-events-auto w-full bg-blue-600 text-white text-center py-4 rounded-md shadow-lg text-lg font-semibold transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+      >
+        Request Notary
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep LayoutWrapper from clipping fixed elements
- show Request Notary button only on small screens and improve placement

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_6861278a4f808327891d2ef961ac4bdd