### PR TITLE
Add accessible FAQ accordion

### DIFF
--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import LayoutWrapper from "../components/LayoutWrapper";
 
 export default function FaqPage() {
@@ -25,6 +25,14 @@ export default function FaqPage() {
     },
   ];
 
+  // Track which FAQ item is currently expanded. Only one can be open at a time.
+  const [openIndex, setOpenIndex] = useState(null);
+
+  // Toggle the open index when a question is clicked
+  const toggle = (index) => {
+    setOpenIndex((prev) => (prev === index ? null : index));
+  };
+
   return (
     <LayoutWrapper>
       <section
@@ -34,16 +42,43 @@ export default function FaqPage() {
         <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
           Frequently Asked Questions
         </h1>
-        <div className="space-y-6 sm:space-y-8">
-          {faqs.map(({ q, a }) => (
-            <div key={q} className="rounded bg-neutral-800 p-6 shadow-sm">
-              <h2 className="text-left text-base sm:text-lg font-medium text-gray-100">
-                {q}
-              </h2>
-              <p className="mt-2 text-left text-gray-400">{a}</p>
+        <dl className="space-y-6 sm:space-y-8">
+          {faqs.map(({ q, a }, idx) => (
+            <div key={q} className="rounded bg-neutral-800 p-4 sm:p-6 shadow-sm">
+              <dt>
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between text-left text-base font-medium text-gray-100 sm:text-lg"
+                  aria-expanded={openIndex === idx}
+                  aria-controls={`faq-panel-${idx}`}
+                  onClick={() => toggle(idx)}
+                >
+                  <span>{q}</span>
+                  <svg
+                    className={`ml-2 h-5 w-5 transform transition-transform duration-300 ${
+                      openIndex === idx ? 'rotate-180' : ''
+                    }`}
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                id={`faq-panel-${idx}`}
+                className={`mt-2 overflow-hidden transition-all duration-300 ${
+                  openIndex === idx ? 'max-h-96' : 'max-h-0'
+                }`}
+                aria-hidden={openIndex !== idx}
+              >
+                <p className="text-left text-gray-400 pb-2">{a}</p>
+              </dd>
             </div>
           ))}
-        </div>
+        </dl>
       </section>
     </LayoutWrapper>
   );

--- a/src/pages/faq.test.js
+++ b/src/pages/faq.test.js
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FaqPage from './faq.jsx';
+
+test('accordion shows one answer at a time', () => {
+  render(
+    <MemoryRouter>
+      <FaqPage />
+    </MemoryRouter>
+  );
+
+  const firstButton = screen.getByRole('button', {
+    name: /what do i need to bring/i,
+  });
+  const secondButton = screen.getByRole('button', {
+    name: /do you offer mobile notary services/i,
+  });
+
+  const firstPanel = screen.getByText(/valid, government-issued/i).parentElement;
+  const secondPanel = screen.getByText(/we travel to your home/i).parentElement;
+
+  // Initially all answers are collapsed
+  expect(firstButton).toHaveAttribute('aria-expanded', 'false');
+  expect(firstPanel).toHaveAttribute('aria-hidden', 'true');
+
+  fireEvent.click(firstButton);
+  expect(firstButton).toHaveAttribute('aria-expanded', 'true');
+  expect(firstPanel).toHaveAttribute('aria-hidden', 'false');
+  expect(secondButton).toHaveAttribute('aria-expanded', 'false');
+
+  fireEvent.click(secondButton);
+  expect(firstButton).toHaveAttribute('aria-expanded', 'false');
+  expect(firstPanel).toHaveAttribute('aria-hidden', 'true');
+  expect(secondButton).toHaveAttribute('aria-expanded', 'true');
+  expect(secondPanel).toHaveAttribute('aria-hidden', 'false');
+});


### PR DESCRIPTION
## Summary
- make the FAQ page interactive with a single-open accordion component
- add a test covering accordion open/close behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68612c386da483279a7c24601576bad1