### PR TITLE
Add Contact CTA banner

### DIFF
--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -16,6 +16,7 @@ export default function ContactPage() {
   return (
     <LayoutWrapper>
       <section
+        id="contact"
         aria-label="Contact"
         className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
       >

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import LayoutWrapper from "../components/LayoutWrapper";
 
 export default function FaqPage() {
@@ -79,6 +80,17 @@ export default function FaqPage() {
             </div>
           ))}
         </dl>
+        <div className="mt-12 rounded-lg border border-blue-500/30 bg-neutral-800 p-6 text-center shadow-inner">
+          <h2 className="mb-4 text-xl font-semibold text-gray-100">
+            Still have questions?
+          </h2>
+          <Link
+            to="/contact#contact"
+            className="inline-block min-h-[48px] rounded-md bg-blue-600 px-6 py-2 font-semibold text-white shadow transition-colors hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+          >
+            Contact Us
+          </Link>
+        </div>
       </section>
     </LayoutWrapper>
   );

--- a/src/pages/faq.test.js
+++ b/src/pages/faq.test.js
@@ -34,3 +34,18 @@ test('accordion shows one answer at a time', () => {
   expect(secondButton).toHaveAttribute('aria-expanded', 'true');
   expect(secondPanel).toHaveAttribute('aria-hidden', 'false');
 });
+
+test('CTA to contact page is present', () => {
+  render(
+    <MemoryRouter>
+      <FaqPage />
+    </MemoryRouter>
+  );
+
+  expect(
+    screen.getByRole('heading', { name: /still have questions/i })
+  ).toBeInTheDocument();
+
+  const link = screen.getByRole('link', { name: /contact us/i });
+  expect(link).toHaveAttribute('href', '/contact#contact');
+});


### PR DESCRIPTION
## Summary
- add `id="contact"` to contact page for anchor navigation
- display CTA banner under FAQ encouraging visitors to contact us
- test the new CTA link

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68614fa3df808327ad62d84868b5deae