### PR TITLE
Improve typography and spacing

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -55,7 +55,7 @@ export default function LandingHero() {
     >
       <section
         id="home"
-        className="relative flex min-h-screen w-full flex-col items-center justify-center bg-black text-gray-200 overflow-hidden py-24 sm:py-32"
+        className="relative flex min-h-screen w-full flex-col items-center justify-center bg-black text-gray-200 overflow-hidden py-12 lg:py-20"
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40"
@@ -67,7 +67,7 @@ export default function LandingHero() {
           aria-hidden="true"
         ></div>
 
-        <div className="relative z-10 mx-auto w-full max-w-screen-md px-4 py-12 text-center sm:py-16">
+        <div className="relative z-10 mx-auto w-full max-w-screen-md px-4 py-12 lg:py-20 text-center">
           <div className="flex flex-col items-center">
             <img
               src="/logo.PNG"
@@ -98,7 +98,7 @@ export default function LandingHero() {
       <section
         id="about"
         aria-label="About"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-24 text-gray-200 sm:px-6 sm:py-32 lg:px-8"
+        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
         <div className="mx-auto max-w-screen-lg text-center">
           <h2 className="mb-8 text-3xl font-bold sm:mb-12">
@@ -137,7 +137,7 @@ export default function LandingHero() {
       <section
         id="services"
         aria-label="Services"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-800 px-4 py-24 text-gray-200 sm:px-6 sm:py-32 lg:px-8"
+        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-800 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="mb-8 text-center text-3xl font-bold sm:mb-12">
@@ -185,7 +185,7 @@ export default function LandingHero() {
       <section
         id="service-area"
         aria-label="Service Area"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-24 text-gray-200 sm:px-6 sm:py-32 lg:px-8"
+        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
         <div className="mx-auto w-full max-w-screen-lg text-center">
           <h2 className="mb-8 text-3xl font-bold sm:mb-12">Service Area</h2>
@@ -208,7 +208,7 @@ export default function LandingHero() {
       <section
         id="faq"
         aria-label="Frequently Asked Questions"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-24 text-gray-200 sm:px-6 sm:py-32 lg:px-8"
+        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="mb-8 text-center text-3xl font-bold sm:mb-12">
@@ -263,7 +263,7 @@ export default function LandingHero() {
       <section
         id="contact"
         aria-label="Contact"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-800 px-4 py-24 text-gray-200 sm:px-6 sm:py-32 lg:px-8"
+        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-800 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="mb-8 text-center text-3xl font-bold sm:mb-12">

--- a/src/index.css
+++ b/src/index.css
@@ -8,4 +8,13 @@
     @apply bg-cover bg-center bg-no-repeat min-h-screen;
     background-image: url('../public/bg-texture.PNG');
   }
+  h1 {
+    @apply text-3xl sm:text-4xl font-extrabold;
+  }
+  h2 {
+    @apply text-2xl sm:text-3xl font-bold;
+  }
+  p {
+    @apply leading-relaxed;
+  }
 }

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -7,10 +7,10 @@ export default function NotFound() {
     <LayoutWrapper>
       <section
         aria-label="Page not found"
-        className="mx-auto max-w-screen-lg px-4 py-12 text-center text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-center text-gray-200 sm:px-6 lg:px-8"
       >
-        <h1 className="mb-4 text-2xl font-semibold sm:text-3xl">404 – Page Not Found</h1>
-        <p className="mb-8 text-gray-400">Sorry, the page you are looking for doesn\'t exist.</p>
+        <h1 className="mb-4 font-extrabold">404 – Page Not Found</h1>
+        <p className="mb-8 text-base sm:text-lg text-gray-400">Sorry, the page you are looking for doesn\'t exist.</p>
         <Link
           to="/"
           className="inline-block rounded-md bg-blue-600 px-6 min-h-[48px] py-2 font-semibold text-white transition-colors hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -6,12 +6,12 @@ export default function AboutPage() {
     <LayoutWrapper>
       <section
         aria-label="About"
-        className="mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
-        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
+        <h1 className="mb-8 text-center font-extrabold">
           About Keystone Notary Group
         </h1>
-        <p className="mx-auto max-w-prose text-left text-gray-300">
+        <p className="mx-auto max-w-prose text-left text-base sm:text-lg text-gray-300">
           Keystone Notary Group, LLC is a mobile notary service dedicated to professionalism,
           punctuality, and privacy. We provide document notarization services throughout Bucks
           and Montgomery County, Pennsylvania.

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -18,9 +18,9 @@ export default function ContactPage() {
       <section
         id="contact"
         aria-label="Contact"
-        className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
-        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
+        <h1 className="mb-8 text-center font-extrabold">
           Contact
         </h1>
         <form onSubmit={handleSubmit} className="space-y-6 sm:space-y-8">
@@ -90,7 +90,7 @@ export default function ContactPage() {
         <p className="mt-8 text-sm text-gray-400 sm:mt-10">
           Please mention the type of document or notarization service you are requesting.
         </p>
-        <div className="mt-4 space-y-2 text-sm text-gray-300">
+        <div className="mt-4 space-y-2 text-base sm:text-lg text-gray-300">
           <p>
             <strong>Phone:</strong>{" "}
             <a

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -38,9 +38,9 @@ export default function FaqPage() {
     <LayoutWrapper>
       <section
         aria-label="Frequently Asked Questions"
-        className="bg-neutral-900 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="bg-neutral-900 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
-        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
+        <h1 className="mb-8 text-center font-extrabold">
           Frequently Asked Questions
         </h1>
         <dl className="space-y-6 sm:space-y-8">
@@ -81,7 +81,7 @@ export default function FaqPage() {
           ))}
         </dl>
         <div className="mt-12 rounded-lg border border-blue-500/30 bg-neutral-800 p-6 text-center shadow-inner">
-          <h2 className="mb-4 text-xl font-semibold text-gray-100">
+          <h2 className="mb-4 font-bold text-gray-100">
             Still have questions?
           </h2>
           <Link

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -6,9 +6,9 @@ export default function ServicesPage() {
     <LayoutWrapper>
       <section
         aria-label="Services"
-        className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 text-gray-200 sm:px-6 sm:py-16 lg:px-8"
+        className="bg-neutral-800 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
       >
-        <h1 className="mb-8 text-center text-2xl font-semibold tracking-wide sm:mb-12 sm:text-3xl">
+        <h1 className="mb-8 text-center font-extrabold">
           Our Services
         </h1>
 


### PR DESCRIPTION
## Summary
- tune heading and paragraph typography in global base layer
- unify spacing between sections using py-12 lg:py-20
- update heading markup across pages for consistent font sizing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686154a98b1483279994e8a4a27fe137