### PR TITLE
Add basic PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This is a small React site styled with Tailwind CSS.
 
+The application includes basic Progressive Web App (PWA) support with an
+offline-capable service worker and web app manifest.
+
 ## Requirements
 
 - Node.js 18 or later

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,11 @@
     <meta property="og:image" content="/logo.PNG" />
     <meta property="og:url" content="https://www.keystonenotarygroup.com/" />
     <meta name="theme-color" content="#111827" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/logo.PNG" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Keystone Notary Group",
+  "short_name": "Keystone Notary",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "icons": [
+    {
+      "src": "/logo.PNG",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logo.PNG",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,34 @@
+const CACHE_NAME = 'kn-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/logo.PNG',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.map(key => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { register as registerServiceWorker } from "./serviceWorkerRegistration";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -9,3 +10,7 @@ root.render(
     <App />
   </React.StrictMode>
 );
+
+if (process.env.NODE_ENV === "production") {
+  registerServiceWorker();
+}

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -1,0 +1,16 @@
+export function register() {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      navigator.serviceWorker
+        .register(swUrl)
+        .catch(error => console.error('Service worker registration failed:', error));
+    });
+  }
+}
+
+export function unregister() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready.then(registration => registration.unregister());
+  }
+}

--- a/src/serviceWorkerRegistration.test.js
+++ b/src/serviceWorkerRegistration.test.js
@@ -1,0 +1,6 @@
+import { register, unregister } from './serviceWorkerRegistration';
+
+test('service worker helpers are functions', () => {
+  expect(typeof register).toBe('function');
+  expect(typeof unregister).toBe('function');
+});


### PR DESCRIPTION
## Summary
- add PWA manifest and service worker
- register the service worker in production builds
- include PWA-related meta tags in the HTML template
- document the new PWA capability
- test service worker registration helpers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68619c387558832794ad3553187b51d5