### PR TITLE
Add GA4 with optional scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ This is a small React site styled with Tailwind CSS.
 The application includes basic Progressive Web App (PWA) support with an
 offline-capable service worker and web app manifest.
 
+## Analytics
+
+Google Analytics 4 tracking is included with privacy-friendly defaults. Update
+the measurement ID in `public/index.html` and adjust consent logic as needed.
+Optional snippets for Hotjar or Microsoft Clarity are also provided in the head
+section but are disabled by default.
+
 ## Requirements
 
 - Node.js 18 or later

--- a/public/index.html
+++ b/public/index.html
@@ -78,6 +78,39 @@
           ]
         }
       </script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      // Deny analytics storage until user consents
+      gtag('consent', 'default', {ad_storage: 'denied', analytics_storage: 'denied'});
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX', { anonymize_ip: true });
+    </script>
+
+    <!-- Optional analytics: uncomment to enable -->
+    <!-- Hotjar Tracking Code
+    <script>
+      (function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:YOUR_HOTJAR_ID,hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
+    -->
+
+    <!-- Microsoft Clarity Tracking Code
+    <script>
+      (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, 'clarity', 'script', 'YOUR_CLARITY_ID');
+    </script>
+    -->
   </head>
   <body style="background-color:#171717;" class="text-gray-200">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add Google Analytics 4 tag with privacy-friendly defaults
- include optional Hotjar and Microsoft Clarity snippets
- document analytics setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68619dabf0b4832799024152d01028a5