### PR TITLE
Enhance site interactions with scroll reveals

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -65,7 +65,7 @@ export default function Header() {
           aria-controls="mobile-menu"
           aria-expanded={open}
           onClick={toggleMenu}
-          className="rounded border border-gray-600 px-6 min-h-[48px] py-1 text-xs uppercase tracking-wide text-gray-200 transition hover:shadow-xl active:shadow-none focus:outline-none focus:ring-2 focus:ring-blue-600 sm:hidden"
+          className="rounded border border-gray-600 px-6 min-h-[48px] py-1 text-xs uppercase tracking-wide text-gray-200 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-md active:shadow-none focus:outline-none focus:ring-2 focus:ring-blue-600 sm:hidden"
         >
           Menu
         </button>
@@ -106,7 +106,7 @@ export default function Header() {
                 to="/"
                 onClick={closeMenu}
                 className={({ isActive }) =>
-                  `block px-2 py-1 transition hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
+                  `block px-2 py-1 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
                 }
               >
                 Home
@@ -117,7 +117,7 @@ export default function Header() {
                 to="/services"
                 onClick={closeMenu}
                 className={({ isActive }) =>
-                  `block px-2 py-1 transition hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
+                  `block px-2 py-1 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
                 }
               >
                 Services
@@ -128,7 +128,7 @@ export default function Header() {
                 to="/faq"
                 onClick={closeMenu}
                 className={({ isActive }) =>
-                  `block px-2 py-1 transition hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
+                  `block px-2 py-1 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
                 }
               >
                 FAQ
@@ -140,7 +140,7 @@ export default function Header() {
                 onClick={closeMenu}
                 ref={lastRef}
                 className={({ isActive }) =>
-                  `block px-2 py-1 transition hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
+                  `block px-2 py-1 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-400${isActive ? " underline text-blue-400" : ""}`
                 }
               >
                 Contact

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import useScrollReveal from "../hooks/useScrollReveal";
 
 export default function LandingHero() {
   // Map labels to in-page anchor targets
@@ -37,6 +38,13 @@ export default function LandingHero() {
   // Track which FAQ item is expanded; only one can be open at a time
   const [openIndex, setOpenIndex] = useState(null);
 
+  const [homeRef, homeVisible] = useScrollReveal();
+  const [aboutRef, aboutVisible] = useScrollReveal();
+  const [servicesRef, servicesVisible] = useScrollReveal();
+  const [areaRef, areaVisible] = useScrollReveal();
+  const [faqRef, faqVisible] = useScrollReveal();
+  const [contactRef, contactVisible] = useScrollReveal();
+
   // Trigger the fade-in shortly after initial render so the transition runs
   useEffect(() => {
     const timer = setTimeout(() => setFadeIn(true), 300);
@@ -55,7 +63,8 @@ export default function LandingHero() {
     >
       <section
         id="home"
-        className="relative flex min-h-screen w-full flex-col items-center justify-center bg-black text-gray-200 overflow-hidden py-12 lg:py-20"
+        ref={homeRef}
+        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-black text-gray-200 overflow-hidden py-12 lg:py-20 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40"
@@ -83,7 +92,7 @@ export default function LandingHero() {
                   <li key={label}>
                     <a
                       href={href}
-                      className="block rounded px-2 py-1 transition hover:shadow-xl hover:text-amber-300 focus:text-amber-300"
+                      className="block rounded px-2 py-1 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-md hover:text-amber-300 focus:text-amber-300"
                     >
                       {label}
                     </a>
@@ -97,13 +106,15 @@ export default function LandingHero() {
       {/* About Section */}
       <section
         id="about"
+        ref={aboutRef}
         aria-label="About"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-screen-lg text-center">
-          <h2 className="mb-8 sm:mb-12">
+          <h2 className="mb-2 sm:mb-4">
             About Keystone Notary Group
           </h2>
+          <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
           {/* Ensure readability on small screens */}
           <p className="mx-auto max-w-prose text-base sm:text-lg text-gray-300">
             Keystone Notary Group, LLC is a mobile notary service dedicated to
@@ -136,13 +147,15 @@ export default function LandingHero() {
       {/* Services Section */}
       <section
         id="services"
+        ref={servicesRef}
         aria-label="Services"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
-          <h2 className="mb-8 text-center sm:mb-12">
+          <h2 className="mb-2 text-center sm:mb-4">
             Our Services
           </h2>
+          <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
           <div className="space-y-8">
             {/* Add subtle dividers between list items for improved readability */}
             <ul className="list-disc list-inside divide-y divide-gray-400/20 space-y-4 text-left text-base sm:text-lg text-gray-300">
@@ -184,11 +197,13 @@ export default function LandingHero() {
       {/* Service Area Section */}
       <section
         id="service-area"
+        ref={areaRef}
         aria-label="Service Area"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${areaVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg text-center">
-          <h2 className="mb-8 sm:mb-12">Service Area</h2>
+          <h2 className="mb-2 sm:mb-4">Service Area</h2>
+          <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
           <p className="mb-8 text-base sm:text-lg text-gray-300">
             We proudly serve Bucks and Montgomery County, Pennsylvania.
           </p>
@@ -207,13 +222,15 @@ export default function LandingHero() {
       {/* FAQ Section */}
       <section
         id="faq"
+        ref={faqRef}
         aria-label="Frequently Asked Questions"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
-          <h2 className="mb-8 text-center sm:mb-12">
+          <h2 className="mb-2 text-center sm:mb-4">
             Frequently Asked Questions
           </h2>
+          <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
           <dl className="space-y-6 sm:space-y-8">
             {faqs.map(({ q, a }, idx) => (
               <div key={q} className="rounded-lg bg-neutral-900 p-6 shadow-md">
@@ -262,13 +279,15 @@ export default function LandingHero() {
       {/* Contact Section */}
       <section
         id="contact"
+        ref={contactRef}
         aria-label="Contact"
-        className="flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
-          <h2 className="mb-8 text-center sm:mb-12">
+          <h2 className="mb-2 text-center sm:mb-4">
             Contact
           </h2>
+          <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
           <form
             onSubmit={(e) => e.preventDefault()}
             className="space-y-6 sm:space-y-8"
@@ -313,7 +332,7 @@ export default function LandingHero() {
               <button
                 type="submit"
                 aria-label="Send Message"
-                className="rounded-md bg-gradient-to-r from-blue-600 to-indigo-600 px-6 min-h-[48px] py-2 font-semibold text-white transition transform hover:scale-105 active:scale-95 hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+                className="rounded-md bg-gradient-to-r from-blue-600 to-indigo-600 px-6 min-h-[48px] py-2 font-semibold text-white transition-transform duration-300 ease-in-out hover:scale-105 active:scale-95 hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
               >
                 Send Message
               </button>
@@ -335,7 +354,7 @@ export default function LandingHero() {
               <strong>Phone:</strong>{" "}
               <a
                 href="tel:2673099000"
-                className="text-blue-400 transition hover:text-blue-300 hover:shadow-xl"
+                className="text-blue-400 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-300 hover:shadow-md"
                 aria-label="Call 267-309-9000"
               >
                 (267) 309-9000
@@ -345,7 +364,7 @@ export default function LandingHero() {
               <strong>Email:</strong>{" "}
               <a
                 href="mailto:appointments@keystonenotarygroup.com"
-                className="text-blue-400 transition hover:text-blue-300 hover:shadow-xl"
+                className="text-blue-400 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-300 hover:shadow-md"
               >
                 appointments@keystonenotarygroup.com
               </a>

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -10,7 +10,7 @@ export default function NavigationBar() {
         <span className="text-lg font-bold text-white">Keystone Notary Group</span>
         <button
           type="button"
-          className="rounded-md bg-white px-6 min-h-[48px] py-2 text-sm font-semibold text-neutral-950 transition hover:bg-neutral-100 hover:shadow-xl active:shadow-none"
+          className="rounded-md bg-white px-6 min-h-[48px] py-2 text-sm font-semibold text-neutral-950 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:bg-neutral-100 hover:shadow-md active:shadow-none"
         >
           Schedule a Signing
         </button>

--- a/src/components/RequestNotaryButton.jsx
+++ b/src/components/RequestNotaryButton.jsx
@@ -42,7 +42,7 @@ export default function RequestNotaryButton() {
         type="button"
         onClick={handleClick}
         aria-label="Request Notary"
-        className="pointer-events-auto w-full bg-blue-600 text-white text-center py-4 rounded-md shadow-lg text-lg font-semibold transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+        className="pointer-events-auto w-full bg-blue-600 text-white text-center py-4 rounded-md shadow-lg text-lg font-semibold transition-transform duration-300 ease-in-out hover:scale-105 active:scale-95 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
       >
         Request Notary
       </button>

--- a/src/hooks/useScrollReveal.js
+++ b/src/hooks/useScrollReveal.js
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Hook to reveal an element when it first enters the viewport.
+ * The observer disconnects after the element is visible to avoid
+ * repeated animations on scroll.
+ */
+export default function useScrollReveal(options = {}) {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry.isIntersecting) {
+        setVisible(true);
+        observer.disconnect();
+      }
+    }, options);
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return [ref, visible];
+}

--- a/src/hooks/useScrollReveal.test.js
+++ b/src/hooks/useScrollReveal.test.js
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import useScrollReveal from './useScrollReveal';
+import React from 'react';
+
+function TestComponent() {
+  const [ref, visible] = useScrollReveal();
+  return <div ref={ref} data-testid="box" className={visible ? 'visible' : ''}></div>;
+}
+
+test('element becomes visible when observed', () => {
+  const observe = jest.fn();
+  const disconnect = jest.fn();
+  global.IntersectionObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe(target) {
+      observe(target);
+      this.cb([{ isIntersecting: true, target }]);
+    }
+    disconnect() {
+      disconnect();
+    }
+  };
+
+  render(<TestComponent />);
+
+  const el = screen.getByTestId('box');
+  expect(observe).toHaveBeenCalledWith(el);
+  expect(el.className).toBe('visible');
+});

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -10,10 +10,11 @@ export default function NotFound() {
         className="bg-black mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-center text-gray-200 sm:px-6 lg:px-8"
       >
         <h1 className="mb-4">404 – Page Not Found</h1>
+        <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mb-8 opacity-60" />
         <p className="mb-8 text-base sm:text-lg text-gray-400">Sorry, the page you are looking for doesn\'t exist.</p>
         <Link
           to="/"
-          className="inline-block rounded-md bg-blue-600 px-6 min-h-[48px] py-2 font-semibold text-white transition-colors hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+          className="inline-block rounded-md bg-blue-600 px-6 min-h-[48px] py-2 font-semibold text-white shadow transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
         >
           Return Home
         </Link>

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -1,16 +1,20 @@
 import React from "react";
+import useScrollReveal from "../hooks/useScrollReveal";
 import LayoutWrapper from "../components/LayoutWrapper";
 
 export default function AboutPage() {
+  const [ref, visible] = useScrollReveal();
   return (
     <LayoutWrapper>
       <section
         aria-label="About"
-        className="bg-neutral-900 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        ref={ref}
+        className={`bg-neutral-900 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <h1 className="mb-8 text-center">
+        <h1 className="mb-2 text-center">
           About Keystone Notary Group
         </h1>
+        <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
         <p className="mx-auto max-w-prose text-left text-base sm:text-lg text-gray-300">
           Keystone Notary Group, LLC is a mobile notary service dedicated to professionalism,
           punctuality, and privacy. We provide document notarization services throughout Bucks

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import LayoutWrapper from "../components/LayoutWrapper";
+import useScrollReveal from "../hooks/useScrollReveal";
 
 export default function ContactPage() {
   const [submitted, setSubmitted] = useState(false);
@@ -13,16 +14,19 @@ export default function ContactPage() {
     setSubmitted(true);
   };
 
+  const [ref, visible] = useScrollReveal();
   return (
     <LayoutWrapper>
       <section
         id="contact"
+        ref={ref}
         aria-label="Contact"
-        className="bg-gray-950 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        className={`bg-gray-950 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <h1 className="mb-8 text-center">
+        <h1 className="mb-2 text-center">
           Contact
         </h1>
+        <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
         <form onSubmit={handleSubmit} className="space-y-6 sm:space-y-8">
           <div>
             <label htmlFor="name" className="block text-sm font-medium">
@@ -64,7 +68,7 @@ export default function ContactPage() {
             <button
               type="submit"
               aria-label="Send Message"
-              className="rounded-md bg-gradient-to-r from-blue-600 to-indigo-600 px-6 min-h-[48px] py-2 font-semibold text-white transition transform hover:scale-105 active:scale-95 hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+              className="rounded-md bg-gradient-to-r from-blue-600 to-indigo-600 px-6 min-h-[48px] py-2 font-semibold text-white transition-transform duration-300 ease-in-out hover:scale-105 active:scale-95 hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
             >
               Send Message
             </button>
@@ -95,7 +99,7 @@ export default function ContactPage() {
             <strong>Phone:</strong>{" "}
             <a
               href="tel:2673099000"
-              className="text-blue-400 hover:text-blue-300"
+              className="text-blue-400 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-300"
               aria-label="Call 267-309-9000"
             >
               (267) 309-9000
@@ -105,7 +109,7 @@ export default function ContactPage() {
             <strong>Email:</strong>{" "}
             <a
               href="mailto:appointments@keystonenotarygroup.com"
-              className="text-blue-400 hover:text-blue-300"
+              className="text-blue-400 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:text-blue-300"
             >
               appointments@keystonenotarygroup.com
             </a>

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import LayoutWrapper from "../components/LayoutWrapper";
+import useScrollReveal from "../hooks/useScrollReveal";
 
 export default function FaqPage() {
   const faqs = [
@@ -34,15 +35,18 @@ export default function FaqPage() {
     setOpenIndex((prev) => (prev === index ? null : index));
   };
 
+  const [ref, visible] = useScrollReveal();
   return (
     <LayoutWrapper>
       <section
         aria-label="Frequently Asked Questions"
-        className="bg-neutral-900 rounded-t-[3rem] mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        ref={ref}
+        className={`bg-neutral-900 rounded-t-[3rem] mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <h1 className="mb-8 text-center">
+        <h1 className="mb-2 text-center">
           Frequently Asked Questions
         </h1>
+        <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
         <dl className="space-y-6 sm:space-y-8">
           {faqs.map(({ q, a }, idx) => (
             <div key={q} className="rounded bg-neutral-800 p-4 sm:p-6 shadow-sm">
@@ -86,7 +90,7 @@ export default function FaqPage() {
           </h2>
           <Link
             to="/contact#contact"
-            className="inline-block min-h-[48px] rounded-md bg-blue-600 px-6 py-2 font-semibold text-white shadow transition-colors hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
+            className="inline-block min-h-[48px] rounded-md bg-blue-600 px-6 py-2 font-semibold text-white shadow transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-neutral-900"
           >
             Contact Us
           </Link>

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -1,16 +1,20 @@
 import React from "react";
 import LayoutWrapper from "../components/LayoutWrapper";
+import useScrollReveal from "../hooks/useScrollReveal";
 
 export default function ServicesPage() {
+  const [ref, visible] = useScrollReveal();
   return (
     <LayoutWrapper>
       <section
         aria-label="Services"
-        className="bg-black mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+        ref={ref}
+        className={`bg-black mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <h1 className="mb-8 text-center">
+        <h1 className="mb-2 text-center">
           Our Services
         </h1>
+        <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
 
         <div className="space-y-8">
           {/* Add subtle dividers between list items for improved readability */}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,12 @@
 import '@testing-library/jest-dom';
+
+// Basic IntersectionObserver mock for tests that rely on it
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof global.IntersectionObserver === 'undefined') {
+  global.IntersectionObserver = MockIntersectionObserver;
+}


### PR DESCRIPTION
## Summary
- animate sections on scroll with new `useScrollReveal` hook
- update links and buttons with smooth hover animations
- add subtle accent lines under section headings
- provide IntersectionObserver mock for tests
- cover new hook in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861d06f233c832795f0a89f2ff9951f