### PR TITLE
Add feather watermark to key sections

### DIFF
--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -22,7 +22,7 @@ export default function ContactPage() {
         id="contact"
         ref={ref}
         aria-label="Contact"
-        className={`bg-gray-950 paper-texture mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative overflow-hidden bg-gray-950 paper-texture mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
       >
         <h1 className="mb-2 text-center">
           Contact
@@ -137,6 +137,22 @@ export default function ContactPage() {
             </p>
           ))}
         </div>
+        {/* Decorative feather watermark */}
+        <svg
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-0 right-0 w-40 md:w-64 opacity-10 -z-10"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z" />
+          <line x1="16" y1="8" x2="2" y2="22" />
+          <line x1="17.5" y1="15" x2="9" y2="15" />
+        </svg>
       </section>
       <section
         ref={bringRef}

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -9,7 +9,7 @@ export default function ServicesPage() {
       <section
         aria-label="Services"
         ref={ref}
-        className={`bg-black mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative overflow-hidden bg-black mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${visible ? "opacity-100 translate-y-0" : ""}`}
       >
         <h1 className="mb-2 text-center">
           Our Services
@@ -54,6 +54,22 @@ export default function ServicesPage() {
           Financial Institutions &bull; Health & Senior Care Providers &bull; Individuals with
           urgent or specialized needs
         </p>
+        {/* Decorative feather watermark */}
+        <svg
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-0 right-0 w-40 md:w-64 opacity-10 -z-10"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z" />
+          <line x1="16" y1="8" x2="2" y2="22" />
+          <line x1="17.5" y1="15" x2="9" y2="15" />
+        </svg>
       </section>
     </LayoutWrapper>
   );


### PR DESCRIPTION
## Summary
- overlay feather watermark in Services section
- overlay feather watermark in Contact section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68624bfec3ac83279a17e8b15323b693