### PR TITLE
Add legal footer row

### DIFF
--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -5,6 +5,7 @@ import Footer from "./Footer";
 import Certifications from "./Certifications";
 import BackToTopButton from "./BackToTopButton";
 import RequestNotaryButton from "./RequestNotaryButton";
+import LegalFooter from "./LegalFooter";
 
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
@@ -109,6 +110,7 @@ export default function LayoutWrapper({ children, fullWidth = false }) {
       </main>
       <Certifications />
       <Footer />
+      <LegalFooter />
       {/* Floating quick access button for mobile devices */}
       <RequestNotaryButton />
       <BackToTopButton />

--- a/src/components/LegalFooter.jsx
+++ b/src/components/LegalFooter.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+/** Slim footer row for legal notices */
+export default function LegalFooter() {
+  return (
+    <div className="bg-black text-xs text-gray-500 py-4 text-center">
+      <p>Licensed & Bonded Notary Public – Pennsylvania</p>
+      <p>Copyright © Keystone Notary Group 2025</p>
+    </div>
+  );
+}

--- a/src/components/LegalFooter.test.js
+++ b/src/components/LegalFooter.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import LegalFooter from './LegalFooter.jsx';
+
+test('renders legal notices', () => {
+  render(<LegalFooter />);
+  expect(screen.getByText(/licensed & bonded notary public/i)).toBeInTheDocument();
+  expect(screen.getByText(/copyright © keystone notary group 2025/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add `LegalFooter` component for thin bottom row
- show the legal footer in `LayoutWrapper`
- test rendering of legal footer text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68624d84cec4832791964fb5be26e7bf