### PR TITLE
Fix hero section duplication and styling

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -55,17 +55,7 @@ export default function Header() {
       }`}
     >
       <h1 className="sr-only">Keystone Notary Group</h1>
-      <div className="mx-auto flex max-w-screen-xl items-center justify-between px-4 sm:px-6">
-        <div className="flex flex-col flex-1 items-center">
-          <img
-            src="/logo.PNG"
-            alt="Keystone Notary Group logo"
-            className="mx-auto w-36 py-4 sm:w-48 sm:py-6"
-          />
-          <p className="text-sm text-gray-400 tracking-wide uppercase text-center">
-            Mobile Notary Services in Pennsylvania
-          </p>
-        </div>
+      <div className="mx-auto flex max-w-screen-xl items-center justify-end px-4 sm:px-6">
         {/* Mobile navigation toggle */}
         <button
           type="button"

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -40,14 +40,15 @@ test('adds shadow when page is scrolled', () => {
   expect(header.className).toMatch(/shadow-sm/);
 });
 
-test('renders tagline below logo', () => {
+test('does not render logo or tagline', () => {
   render(
     <MemoryRouter>
       <Header />
     </MemoryRouter>
   );
 
+  expect(screen.queryByAltText(/keystone notary group logo/i)).toBeNull();
   expect(
-    screen.getByText(/mobile notary services in pennsylvania/i)
-  ).toBeInTheDocument();
+    screen.queryByText(/mobile notary services in pennsylvania/i)
+  ).toBeNull();
 });

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -62,7 +62,7 @@ export default function LandingHero() {
       <section
         id="home"
         ref={homeRef}
-        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-black text-gray-200 overflow-hidden py-12 lg:py-20 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-gradient-to-b from-gray-900 via-gray-950 to-black text-gray-200 overflow-hidden py-8 sm:py-12 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40"
@@ -74,19 +74,15 @@ export default function LandingHero() {
           aria-hidden="true"
         ></div>
 
-        <div className="relative z-10 mx-auto w-full max-w-screen-md px-4 py-12 lg:py-20 text-center">
-          <div
-            className="flex flex-col items-center border-b border-gray-800 bg-gradient-to-b from-black via-gray-950 to-transparent pb-4 pt-4"
-          >
-            <img
-              src="/logo.PNG"
-              alt="Keystone Notary Group logo"
-              className="mx-auto mb-4 w-32 sm:w-36 md:w-40"
-            />
-            <p className="text-xs uppercase tracking-wide text-gray-400">
-              Mobile Notary Services • Pennsylvania
-            </p>
-          </div>
+        <div className="relative z-10 mx-auto flex w-full max-w-screen-md flex-col items-center px-4">
+          <img
+            src="/logo.PNG"
+            alt="Keystone Notary Group logo"
+            className="w-36 md:w-48"
+          />
+          <p className="mt-4 mb-8 text-center text-gray-300 tracking-wide">
+            Mobile Notary Services in Pennsylvania
+          </p>
           <nav
             className="mt-8 sm:mt-10 border-b border-gray-700 pb-4 shadow-md"
             aria-label="Main navigation"

--- a/src/components/LandingHero.test.js
+++ b/src/components/LandingHero.test.js
@@ -30,3 +30,12 @@ test("FAQ accordion shows only one open panel at a time", () => {
   expect(second).toHaveAttribute("aria-expanded", "true");
   expect(secondPanel).toHaveAttribute("aria-hidden", "false");
 });
+
+test("renders logo and tagline", () => {
+  render(<LandingHero />);
+
+  expect(screen.getByAltText(/keystone notary group logo/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(/mobile notary services in pennsylvania/i)
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- remove branding from the header component
- simplify hero structure and styling
- show tagline only once in hero
- update related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686386fdb9608327a4eaf459434fefb4