### PR TITLE
Add smooth section reveals and interactive polish

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -62,7 +62,7 @@ export default function LandingHero() {
       <section
         id="home"
         ref={homeRef}
-        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-gradient-to-b from-gray-900 via-gray-950 to-black text-gray-200 overflow-hidden py-8 sm:py-12 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-gradient-to-b from-gray-900 via-gray-950 to-black text-gray-200 overflow-hidden py-8 sm:py-12 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40"
@@ -75,6 +75,11 @@ export default function LandingHero() {
         ></div>
 
         <div className="relative z-10 mx-auto flex w-full max-w-screen-md flex-col items-center px-4">
+          {/* Subtle glow behind logo */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-10 left-1/2 h-40 w-40 -translate-x-1/2 rounded-full bg-gradient-radial from-blue-600/20 via-blue-600/10 to-transparent blur-2xl"
+          />
           <img
             src="/logo.PNG"
             alt="Keystone Notary Group logo"
@@ -113,7 +118,7 @@ export default function LandingHero() {
         id="about"
         ref={aboutRef}
         aria-label="About"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-screen-lg text-center">
           <h2 className="mb-2 sm:mb-4">
@@ -154,7 +159,7 @@ export default function LandingHero() {
         id="services"
         ref={servicesRef}
         aria-label="Services"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 paper-texture px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 paper-texture px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="mb-2 text-center sm:mb-4">
@@ -209,7 +214,7 @@ export default function LandingHero() {
         id="faq"
         ref={faqRef}
         aria-label="Frequently Asked Questions"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="mb-2 text-center sm:mb-4">
@@ -272,7 +277,7 @@ export default function LandingHero() {
         id="contact"
         ref={contactRef}
         aria-label="Contact"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 paper-texture rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-6 transition-all duration-700 ease-in-out ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 paper-texture rounded-t-[3rem] px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="mb-2 text-center sm:mb-4">

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -14,6 +14,11 @@ export default function LayoutWrapper({ children, fullWidth = false }) {
       /* Ensure pages share consistent textured background */
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
+      {/* Soft radial accent for subtle depth */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-10 -left-10 h-72 w-72 rounded-full bg-gradient-radial from-blue-600/20 via-blue-600/10 to-transparent blur-3xl animate-pulse-slow"
+      />
       <Helmet>
         <title>Keystone Notary Group – Mobile Notary Services</title>
         <meta

--- a/src/components/RequestNotaryButton.jsx
+++ b/src/components/RequestNotaryButton.jsx
@@ -45,7 +45,7 @@ export default function RequestNotaryButton() {
         aria-label="Request Notary"
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
-        className="pointer-events-auto w-full bg-blue-600 text-white text-center py-4 rounded-md shadow-lg text-lg font-semibold transition-transform duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+        className="relative pointer-events-auto w-full bg-blue-600 text-white text-center py-4 rounded-md shadow-lg text-lg font-semibold transition-all duration-300 hover:bg-blue-700 hover:shadow-[0_0_10px_rgba(59,130,246,0.7)] focus:outline-none focus:ring-2 focus:ring-blue-400 ring-1 ring-blue-500/40 before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-gradient-radial before:from-blue-600/30 before:to-transparent before:blur-2xl"
       >
         Request Notary
       </motion.button>

--- a/src/components/RequestNotaryButton.test.js
+++ b/src/components/RequestNotaryButton.test.js
@@ -15,6 +15,9 @@ test('navigates to contact section when clicked', () => {
     </MemoryRouter>
   );
 
-  fireEvent.click(screen.getByRole('button', { name: /request notary/i }));
+  const button = screen.getByRole('button', { name: /request notary/i });
+  expect(button.className).toMatch(/shadow-\[0_0_10px_rgba\(59,130,246,0.7\)\]/);
+
+  fireEvent.click(button);
   expect(mockNavigate).toHaveBeenCalledWith('/contact#contact');
 });

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -13,7 +13,7 @@ export default function AboutPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="bg-neutral-900 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
+          className="bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mx-auto max-w-screen-lg px-4 py-12 lg:py-20 text-gray-200 sm:px-6 lg:px-8"
         >
         <h1 className="mb-2 text-center">
           About Keystone Notary Group

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -25,7 +25,7 @@ export default function ContactPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="relative overflow-hidden bg-neutral-950 paper-texture mx-auto max-w-screen-lg px-4 pt-20 pb-24 text-gray-200 sm:px-6 lg:px-8"
+          className="relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 paper-texture mx-auto max-w-screen-lg px-4 pt-20 pb-24 text-gray-200 sm:px-6 lg:px-8"
         >
         <h1 className="mb-2 text-center">
           Contact
@@ -146,7 +146,7 @@ export default function ContactPage() {
         {/* Decorative feather watermark */}
         <svg
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-0 right-0 w-40 md:w-64 opacity-10 -z-10"
+          className="pointer-events-none absolute bottom-0 right-0 w-40 md:w-64 opacity-10 -z-10 animate-spin-slow"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"
@@ -167,7 +167,7 @@ export default function ContactPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="bg-black mx-auto mt-12 max-w-screen-md px-4 pt-20 pb-24"
+          className="bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mx-auto mt-12 max-w-screen-md px-4 pt-20 pb-24"
         >
           <div className="bg-neutral-900 p-6 rounded-md">
           <div className="mb-8 flex items-center justify-center">

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -44,7 +44,7 @@ export default function FaqPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="bg-black rounded-t-[3rem] mx-auto max-w-screen-lg px-4 pt-20 pb-24 text-gray-200 sm:px-6 lg:px-8"
+          className="bg-gradient-to-b from-neutral-900 via-black to-neutral-950 rounded-t-[3rem] mx-auto max-w-screen-lg px-4 pt-20 pb-24 text-gray-200 sm:px-6 lg:px-8"
         >
         <h1 className="mb-2 text-center">
           Frequently Asked Questions

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -13,7 +13,7 @@ export default function ServicesPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="relative overflow-hidden bg-neutral-950 mx-auto max-w-screen-lg px-4 pt-20 pb-24 text-gray-200 sm:px-6 lg:px-8"
+          className="relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mx-auto max-w-screen-lg px-4 pt-20 pb-24 text-gray-200 sm:px-6 lg:px-8"
         >
           <h1 className="mb-2 text-center">Our Services</h1>
           <div aria-hidden="true" className="border-t border-gray-600 w-12 mx-auto mt-4 opacity-60" />
@@ -59,7 +59,7 @@ export default function ServicesPage() {
         {/* Decorative feather watermark */}
         <svg
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-0 right-0 w-40 md:w-64 opacity-10 -z-10"
+          className="pointer-events-none absolute bottom-0 right-0 w-40 md:w-64 opacity-10 -z-10 animate-spin-slow"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,11 +4,17 @@ module.exports = {
     extend: {
       animation: {
         fadeIn: 'fadeIn 1000ms ease-out forwards',
+        slideUp: 'slideUp 700ms ease-out forwards',
+        'spin-slow': 'spin 12s linear infinite',
       },
       keyframes: {
         fadeIn: {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },
+        },
+        slideUp: {
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- fine-tune fade-in animations and add slideUp/slow spin utilities
- polish home hero with a glowing radial accent
- add mobile call-to-action glow effect and test for hover styling
- layer in soft radial backdrop and animated watermark accents
- use subtle gradients on main content sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863d7166d088327b393d80557232bfc