### PR TITLE
Add Back to Top threshold

### DIFF
--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -2,13 +2,15 @@ import React, { useEffect, useState } from "react";
 
 /**
  * Floating button that smoothly scrolls the page back to the top.
- * Appears after the user scrolls down 400px.
+ * Appears after the user scrolls beyond 50% of the viewport height.
  */
 export default function BackToTopButton() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => setVisible(window.scrollY > 400);
+    // Show button once the user has scrolled more than half a viewport height
+    const handleScroll = () =>
+      setVisible(window.scrollY > window.innerHeight / 2);
     window.addEventListener("scroll", handleScroll);
     handleScroll(); // run on mount
     return () => window.removeEventListener("scroll", handleScroll);
@@ -23,7 +25,7 @@ export default function BackToTopButton() {
       type="button"
       onClick={scrollToTop}
       aria-label="Back to top"
-      className={`fixed bottom-8 right-8 z-50 rounded-full bg-blue-600 p-3 text-white shadow-md transition-opacity duration-300 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 ${visible ? "opacity-100" : "pointer-events-none opacity-0"}`}
+      className={`fixed bottom-6 right-4 z-50 rounded-full bg-blue-600 p-3 text-white shadow-md transition-opacity duration-300 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 ${visible ? "opacity-100" : "pointer-events-none opacity-0"}`}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/BackToTopButton.test.js
+++ b/src/components/BackToTopButton.test.js
@@ -3,6 +3,7 @@ import BackToTopButton from './BackToTopButton.jsx';
 
 test('shows button after scrolling and scrolls to top when clicked', () => {
   Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: 0 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
   const scrollToMock = jest.fn();
   window.scrollTo = scrollToMock;
   render(<BackToTopButton />);
@@ -10,7 +11,7 @@ test('shows button after scrolling and scrolls to top when clicked', () => {
   const button = screen.getByRole('button', { name: /back to top/i });
   expect(button.className).toMatch(/pointer-events-none/);
 
-  window.scrollY = 500;
+  window.scrollY = 401; // > 50vh of 800
   fireEvent.scroll(window);
   expect(button.className).not.toMatch(/pointer-events-none/);
 


### PR DESCRIPTION
## Summary
- show the BackToTop button when scrolled beyond 50vh
- adjust position to bottom-6 right-4
- update unit tests for new threshold

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863f07630f08327b2b65a2ce38472a7