### PR TITLE
Add contact form validation and tests

### DIFF
--- a/src/pages/contact.test.js
+++ b/src/pages/contact.test.js
@@ -1,18 +1,37 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ContactPage from './contact.jsx';
 
-test('shows confirmation message on successful form submission', () => {
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('submits form and shows confirmation message', async () => {
   render(
     <MemoryRouter>
       <ContactPage />
     </MemoryRouter>
   );
-  fireEvent.change(screen.getByLabelText(/full name/i), { target: { value: 'John' } });
-  fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } });
-  fireEvent.change(screen.getByLabelText(/^Message$/i), { target: { value: 'Hello' } });
+
+  fireEvent.change(screen.getByLabelText(/full name/i), {
+    target: { value: 'John' },
+  });
+  fireEvent.change(screen.getByLabelText(/email address/i), {
+    target: { value: 'john@example.com' },
+  });
+  fireEvent.change(screen.getByLabelText(/^Message$/i), {
+    target: { value: 'Hello' },
+  });
 
   fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+  await waitFor(() => {
+    expect(fetch).toHaveBeenCalledWith('/api/contact', expect.any(Object));
+  });
 
   expect(
     screen.getByText(/thank you! your message has been sent/i)
@@ -21,4 +40,42 @@ test('shows confirmation message on successful form submission', () => {
   expect(screen.getByLabelText(/full name/i).value).toBe('');
   expect(screen.getByLabelText(/email address/i).value).toBe('');
   expect(screen.getByLabelText(/^Message$/i).value).toBe('');
+});
+
+test('shows validation errors for empty fields', () => {
+  render(
+    <MemoryRouter>
+      <ContactPage />
+    </MemoryRouter>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+  expect(fetch).not.toHaveBeenCalled();
+  expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+  expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+  expect(screen.getByText(/message is required/i)).toBeInTheDocument();
+});
+
+test('shows validation error for invalid email', () => {
+  render(
+    <MemoryRouter>
+      <ContactPage />
+    </MemoryRouter>
+  );
+
+  fireEvent.change(screen.getByLabelText(/full name/i), {
+    target: { value: 'John' },
+  });
+  fireEvent.change(screen.getByLabelText(/email address/i), {
+    target: { value: 'invalid-email' },
+  });
+  fireEvent.change(screen.getByLabelText(/^Message$/i), {
+    target: { value: 'Hello' },
+  });
+
+  fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+  expect(fetch).not.toHaveBeenCalled();
+  expect(screen.getByText(/enter a valid email/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- validate fields in contact form
- display accessible error messages and integrate fetch API
- add tests for form submission and validation cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866686b4e3083278bc39227c516efbb