### PR TITLE
Inject GA ID from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ offline-capable service worker and web app manifest.
 
 ## Analytics
 
-Google Analytics 4 tracking is included with privacy-friendly defaults. Update
-the measurement ID in `public/index.html` and adjust consent logic as needed.
+Google Analytics 4 tracking is included with privacy-friendly defaults. Set the
+`REACT_APP_GA_ID` environment variable before running `npm run build`. The build
+script will inject this ID into `build/index.html` in place of the placeholder
+value, keeping the source file free of sensitive data. Adjust the consent logic
+as needed.
 Optional snippets for Hotjar or Microsoft Clarity are also provided in the head
 section but are disabled by default.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && node scripts/inject-ga.js",
     "test": "react-scripts test --watchAll=false"
   },
   "engines": {

--- a/public/index.html
+++ b/public/index.html
@@ -87,14 +87,14 @@
         }
       </script>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       // Deny analytics storage until user consents
       gtag('consent', 'default', {ad_storage: 'denied', analytics_storage: 'denied'});
       gtag('js', new Date());
-      gtag('config', 'G-XXXXXXXXXX', { anonymize_ip: true });
+      gtag('config', 'GA_MEASUREMENT_ID', { anonymize_ip: true });
     </script>
 
     <!-- Optional analytics: uncomment to enable -->

--- a/scripts/inject-ga.js
+++ b/scripts/inject-ga.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const buildIndexPath = path.join(__dirname, '../build/index.html');
+const gaId = process.env.REACT_APP_GA_ID;
+
+if (!gaId) {
+  console.warn('REACT_APP_GA_ID not set; skipping GA ID injection.');
+  process.exit(0);
+}
+
+try {
+  let html = fs.readFileSync(buildIndexPath, 'utf8');
+  html = html.replace(/GA_MEASUREMENT_ID/g, gaId);
+  fs.writeFileSync(buildIndexPath, html);
+  console.log(`Injected Google Analytics ID ${gaId} into build/index.html`);
+} catch (err) {
+  console.error('Failed to inject GA ID:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- use a placeholder GA_MEASUREMENT_ID in `public/index.html`
- inject the real GA ID after the build using a Node script
- document how to set `REACT_APP_GA_ID` for builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68666babe8508327883fbf4a19db07ff