### PR TITLE
Add sitemap generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && node scripts/inject-ga.js",
-    "test": "react-scripts test --watchAll=false"
+    "build": "npm run generate-sitemap && react-scripts build && node scripts/inject-ga.js",
+    "test": "react-scripts test --watchAll=false",
+    "generate-sitemap": "node scripts/generate-sitemap.js"
   },
   "engines": {
     "node": ">=18"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://localhost</loc></url>
+  <url><loc>http://localhost/services</loc></url>
+  <url><loc>http://localhost/about</loc></url>
+  <url><loc>http://localhost/faq</loc></url>
+  <url><loc>http://localhost/contact</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+const appJsPath = path.join(__dirname, '../src/App.js');
+const publicDir = path.join(__dirname, '../public');
+const sitemapPath = path.join(publicDir, 'sitemap.xml');
+const robotsPath = path.join(publicDir, 'robots.txt');
+
+function getRoutes() {
+  const content = fs.readFileSync(appJsPath, 'utf8');
+  const regex = /<Route\s+path=\"([^\"*]+)\"/g;
+  const routes = [];
+  let match;
+  while ((match = regex.exec(content))) {
+    routes.push(match[1]);
+  }
+  return Array.from(new Set(routes));
+}
+
+function generateSitemap(routes) {
+  const base = process.env.SITEMAP_BASE_URL || 'http://localhost';
+  const urls = routes.map(r => {
+    const loc = r === '/' ? base : `${base}${r}`;
+    return `  <url><loc>${loc}</loc></url>`;
+  }).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+function generateRobots() {
+  return `User-agent: *\nAllow: /\nSitemap: /sitemap.xml\n`;
+}
+
+function main() {
+  const routes = getRoutes();
+  const xml = generateSitemap(routes);
+  fs.writeFileSync(sitemapPath, xml);
+  fs.writeFileSync(robotsPath, generateRobots());
+  console.log('Sitemap and robots.txt generated');
+}
+
+if (require.main === module) {
+  main();
+}

--- a/src/sitemap.test.js
+++ b/src/sitemap.test.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+describe('sitemap generation', () => {
+  beforeAll(() => {
+    execSync('npm run build', { stdio: 'inherit' });
+  }, 300000); // allow up to 5 minutes for build
+
+  test('sitemap.xml exists in build directory', () => {
+    const sitemapPath = path.join(__dirname, '..', 'build', 'sitemap.xml');
+    expect(fs.existsSync(sitemapPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add generator script for sitemap and robots.txt
- update build script to generate sitemap before build
- create unit test ensuring sitemap exists after build

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68666cd8d3e88327a5e213dd3e421067