### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Certifications() {
   return (
-    <section className="bg-gray-950 paper-texture text-gray-200 py-16 lg:py-24">
+    <section className="bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 py-16 lg:py-24">
       <div className="mx-auto max-w-screen-lg px-4 sm:px-6 lg:px-8">
         <h2 className="mb-8 text-center">
           Certifications & Credentials

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 export default function Footer() {
   return (
-    <footer className="bg-neutral-900 text-gray-500">
+    <footer className="bg-gray-100 text-gray-600 dark:bg-neutral-900 dark:text-gray-500">
       <div className="mx-auto max-w-screen-lg px-4 py-3 text-center sm:px-6 lg:px-8">
         <div className="mx-auto max-w-screen-xl px-4 py-3 text-center">
           {/* Static copyright text for legal clarity */}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,6 +5,7 @@ import { NavLink } from "react-router-dom";
 export default function Header() {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [dark, setDark] = useState(false);
   const firstRef = useRef(null);
   const lastRef = useRef(null);
 
@@ -20,6 +21,24 @@ export default function Header() {
       body.classList.remove("overflow-hidden");
     }
   }, [open]);
+
+  // Initialize theme from localStorage or system preference
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const enabled = stored ? stored === 'dark' : prefersDark;
+    document.body.classList.toggle('dark', enabled);
+    setDark(enabled);
+  }, []);
+
+  const toggleTheme = () => {
+    setDark((prev) => {
+      const next = !prev;
+      document.body.classList.toggle('dark', next);
+      localStorage.setItem('theme', next ? 'dark' : 'light');
+      return next;
+    });
+  };
 
   // Toggle a subtle shadow once the user scrolls down the page
   useEffect(() => {
@@ -50,12 +69,21 @@ export default function Header() {
   return (
     <header
       role="banner"
-      className={`fixed top-0 left-0 right-0 z-50 border-b border-gray-800 bg-gradient-to-b from-gray-900 via-gray-950 to-black backdrop-blur text-gray-200 transition-shadow duration-300 ${
+      className={`fixed top-0 left-0 right-0 z-50 border-b backdrop-blur transition-shadow duration-300 bg-white/70 text-gray-800 border-gray-200 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 dark:border-gray-800 ${
         scrolled ? "shadow-sm" : "shadow-none"
       }`}
     >
       <h1 className="sr-only">Keystone Notary Group</h1>
       <div className="mx-auto flex max-w-screen-xl items-center justify-end px-4 sm:px-6">
+        {/* Theme toggle button */}
+        <button
+          type="button"
+          aria-label="Toggle dark mode"
+          onClick={toggleTheme}
+          className="rounded border border-gray-600 px-3 min-h-[36px] py-1 text-xs uppercase tracking-wide text-gray-800 dark:text-gray-200 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-md active:shadow-none focus:outline-none focus:ring-2 focus:ring-blue-600 mr-4"
+        >
+          {dark ? 'Light' : 'Dark'}
+        </button>
         {/* Mobile navigation toggle */}
         <button
           type="button"
@@ -63,7 +91,7 @@ export default function Header() {
           aria-controls="mobile-menu"
           aria-expanded={open}
           onClick={toggleMenu}
-          className="ml-4 rounded border border-gray-600 px-6 min-h-[48px] py-1 text-xs uppercase tracking-wide text-gray-200 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-md active:shadow-none focus:outline-none focus:ring-2 focus:ring-blue-600 sm:hidden"
+          className="ml-4 rounded border border-gray-600 px-6 min-h-[48px] py-1 text-xs uppercase tracking-wide text-gray-800 dark:text-gray-200 transition-transform duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-md active:shadow-none focus:outline-none focus:ring-2 focus:ring-blue-600 sm:hidden"
         >
           Menu
         </button>
@@ -85,7 +113,7 @@ export default function Header() {
             aria-label="Mobile"
             onKeyDown={handleKeyDown}
             onClick={(e) => e.stopPropagation()}
-            className={`fixed right-0 top-0 bottom-0 w-64 transform bg-gray-900 text-white shadow-xl transition-all duration-300 ${
+            className={`fixed right-0 top-0 bottom-0 w-64 transform bg-white text-gray-800 dark:bg-gray-900 dark:text-white shadow-xl transition-all duration-300 ${
               open ? "translate-x-0" : "translate-x-full"
             }`}
           >
@@ -94,7 +122,7 @@ export default function Header() {
               aria-label="Close menu"
               onClick={closeMenu}
               ref={firstRef}
-              className="absolute top-4 right-4 text-white text-2xl z-50 focus:outline-none"
+              className="absolute top-4 right-4 text-gray-800 dark:text-white text-2xl z-50 focus:outline-none"
             >
               &times;
             </button>

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -52,3 +52,18 @@ test('does not render logo or tagline', () => {
     screen.queryByText(/mobile notary services in pennsylvania/i)
   ).toBeNull();
 });
+
+test('theme toggle updates body class', () => {
+  render(
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>
+  );
+
+  const toggle = screen.getByRole('button', { name: /toggle dark mode/i });
+  expect(document.body).not.toHaveClass('dark');
+  fireEvent.click(toggle);
+  expect(document.body).toHaveClass('dark');
+  fireEvent.click(toggle);
+  expect(document.body).not.toHaveClass('dark');
+});

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -71,7 +71,7 @@ export default function LandingHero() {
       <section
         id="home"
         ref={homeRef}
-        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-gradient-to-b from-gray-900 via-gray-950 to-black text-gray-200 overflow-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative flex min-h-screen w-full flex-col items-center justify-center bg-white text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 overflow-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40"
@@ -168,7 +168,7 @@ export default function LandingHero() {
         id="about"
         ref={aboutRef}
         aria-label="About"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 px-4 py-16 lg:py-24 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-screen-lg text-center">
           <h2>
@@ -183,16 +183,16 @@ export default function LandingHero() {
             Pennsylvania.
           </p>
           <div className="mt-10 grid gap-6 sm:mt-12 sm:grid-cols-2">
-            <div className="rounded-lg bg-neutral-900 p-6 text-center shadow-md">
+            <div className="rounded-lg bg-gray-200 text-gray-800 dark:bg-neutral-900 dark:text-gray-100 p-6 text-center shadow-md">
               <p className="font-medium">Certified Loan Signing Agent</p>
             </div>
-            <div className="rounded-lg bg-neutral-900 p-6 text-center shadow-md">
+            <div className="rounded-lg bg-gray-200 text-gray-800 dark:bg-neutral-900 dark:text-gray-100 p-6 text-center shadow-md">
               <p className="font-medium">NNA Certified and Insured</p>
             </div>
-            <div className="rounded-lg bg-neutral-900 p-6 text-center shadow-md">
+            <div className="rounded-lg bg-gray-200 text-gray-800 dark:bg-neutral-900 dark:text-gray-100 p-6 text-center shadow-md">
               <p className="font-medium">Serving Bucks & Montgomery County</p>
             </div>
-            <div className="rounded-lg bg-neutral-900 p-6 text-center shadow-md">
+            <div className="rounded-lg bg-gray-200 text-gray-800 dark:bg-neutral-900 dark:text-gray-100 p-6 text-center shadow-md">
               <p className="font-medium">
                 After-Hours & Emergency Services Available
               </p>
@@ -209,7 +209,7 @@ export default function LandingHero() {
         id="services"
         ref={servicesRef}
         aria-label="Services"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 paper-texture px-4 py-16 lg:py-24 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="text-center">
@@ -279,7 +279,7 @@ export default function LandingHero() {
         id="faq"
         ref={faqRef}
         aria-label="Frequently Asked Questions"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-neutral-900 rounded-t-[3rem] px-4 py-16 lg:py-24 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 rounded-t-[3rem] px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="text-center">
@@ -290,7 +290,7 @@ export default function LandingHero() {
             {faqs.map(({ q, a }, idx) => (
               <div
                 key={q}
-                className={`rounded-lg bg-neutral-900 p-6 shadow-md opacity-0 translate-y-3 transition-all duration-700 ease-in-out ${
+                className={`rounded-lg bg-gray-200 text-gray-800 dark:bg-neutral-900 dark:text-gray-100 p-6 shadow-md opacity-0 translate-y-3 transition-all duration-700 ease-in-out ${
                   faqVisible ? 'opacity-100 translate-y-0' : ''
                 }`}
                 style={{ transitionDelay: `${idx * 100}ms` }}
@@ -342,7 +342,7 @@ export default function LandingHero() {
         id="contact"
         ref={contactRef}
         aria-label="Contact"
-        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-950 paper-texture rounded-t-[3rem] px-4 py-16 lg:py-24 text-gray-200 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-screen w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 rounded-t-[3rem] px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto w-full max-w-screen-lg">
           <h2 className="text-center">

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -11,7 +11,7 @@ import ScrollProgress from "./ScrollProgress";
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
-      className="scroll-smooth relative flex min-h-screen w-full flex-col overflow-x-hidden brightness-125 contrast-110 text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
+      className="scroll-smooth relative flex min-h-screen w-full flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
       /* Ensure pages share consistent textured background */
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -5,18 +5,19 @@
 @layer base {
   /* Global background pattern */
   body {
-    @apply scroll-smooth bg-cover bg-center bg-no-repeat min-h-screen font-sans text-[17px] sm:text-[18px] font-medium leading-relaxed sm:leading-loose tracking-normal sm:tracking-wide;
+    @apply scroll-smooth bg-cover bg-center bg-no-repeat min-h-screen font-sans text-[17px] sm:text-[18px] font-medium leading-relaxed sm:leading-loose tracking-normal sm:tracking-wide bg-white text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200;
     background-image: url('../public/bg-texture.PNG');
   }
-  h1, h2 {
+  h1,
+  h2 {
     /* Consistent heading scale */
-    @apply font-display text-3xl sm:text-4xl font-semibold tracking-tight text-white mb-6;
+    @apply font-display text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900 mb-6 dark:text-white;
   }
   h3 {
-    @apply font-display text-2xl sm:text-3xl font-semibold tracking-tight text-white mb-4;
+    @apply font-display text-2xl sm:text-3xl font-semibold tracking-tight text-gray-900 mb-4 dark:text-white;
   }
   p {
-    @apply text-lg text-gray-300 leading-relaxed tracking-normal;
+    @apply text-lg text-gray-700 leading-relaxed tracking-normal dark:text-gray-300;
   }
 }
 @layer utilities {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -10,3 +10,17 @@ class MockIntersectionObserver {
 if (typeof global.IntersectionObserver === 'undefined') {
   global.IntersectionObserver = MockIntersectionObserver;
 }
+
+// Provide a basic matchMedia mock for components relying on it
+if (typeof window.matchMedia === 'undefined') {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{js,jsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- style base elements for light and dark themes
- update layout and hero sections with `dark:` variants
- add persistent dark mode toggle to header
- update footer and certification sections for light mode
- mock `matchMedia` for tests
- test dark mode toggle functionality

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68667fc76ea48327a84145ac32b449a9