### PR TITLE
Fix readability in light mode

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -116,13 +116,13 @@ export default function LandingHero() {
           <motion.img
             src="/logo.PNG"
             alt="Keystone Notary Group logo"
-            className="w-36 md:w-48"
+            className="w-36 md:w-48 invert dark:invert-0 drop-shadow"
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: "easeOut" }}
           />
           <motion.p
-            className="mt-4 mb-4 text-center text-gray-300 tracking-wide"
+            className="mt-4 mb-4 text-center text-gray-700 dark:text-gray-300 tracking-wide"
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: "easeOut", delay: 0.15 }}
@@ -142,7 +142,7 @@ export default function LandingHero() {
             className="mt-8 sm:mt-10 border-b border-gray-700 pb-4 shadow-md"
             aria-label="Main navigation"
             >
-              <ul className="flex flex-col items-center space-y-3 sm:space-y-6 text-sm sm:text-base font-medium uppercase text-gray-300">
+              <ul className="flex flex-col items-center space-y-3 sm:space-y-6 text-sm sm:text-base font-medium uppercase text-gray-700 dark:text-gray-300">
                 {navItems.map(({ label, href }, idx) => (
                   <li
                     key={label}
@@ -176,7 +176,7 @@ export default function LandingHero() {
           </h2>
           <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />
           {/* Ensure readability on all devices */}
-          <p className="mx-auto max-w-3xl text-lg text-gray-300 leading-relaxed tracking-normal">
+          <p className="mx-auto max-w-3xl text-lg text-gray-700 dark:text-gray-300 leading-relaxed tracking-normal">
             Keystone Notary Group, LLC is a mobile notary service dedicated to
             professionalism, punctuality, and privacy. We provide document
             notarization services throughout Bucks and Montgomery County,
@@ -198,7 +198,7 @@ export default function LandingHero() {
               </p>
             </div>
           </div>
-          <p className="mt-10 text-sm text-gray-400">
+          <p className="mt-10 text-sm text-gray-600 dark:text-gray-400">
             Commissioned in the Commonwealth of Pennsylvania
           </p>
         </div>
@@ -218,7 +218,7 @@ export default function LandingHero() {
           <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />
           <div className="space-y-8">
             {/* Add subtle dividers between list items for improved readability */}
-            <ul className="list-disc list-inside divide-y divide-gray-400/20 space-y-4 text-left text-base sm:text-lg text-gray-300">
+            <ul className="list-disc list-inside divide-y divide-gray-400/20 space-y-4 text-left text-base sm:text-lg text-gray-700 dark:text-gray-300">
               {[
                 'General notary work including acknowledgments, oaths, affirmations, and signature witnessing',
                 'Loan signing services for real estate closings, refinances, and mortgage documents',
@@ -245,7 +245,7 @@ export default function LandingHero() {
                 </li>
               ))}
             </ul>
-            <p className="mt-6 text-center text-base sm:text-lg text-gray-300">
+            <p className="mt-6 text-center text-base sm:text-lg text-gray-700 dark:text-gray-300">
               <strong>We proudly work with:</strong>
               <br />
               Homeowners &bull; Attorneys &bull; Title Companies &bull; Real
@@ -301,7 +301,7 @@ export default function LandingHero() {
                     aria-expanded={openIndex === idx}
                     aria-controls={`faq-panel-${idx}`}
                     onClick={() => toggleFaq(idx)}
-                    className="flex w-full items-center justify-between text-left text-base font-medium text-gray-100 sm:text-lg"
+                    className="flex w-full items-center justify-between text-left text-base font-medium text-gray-800 dark:text-gray-100 sm:text-lg"
                   >
                     <span>{q}</span>
                     <svg
@@ -325,7 +325,7 @@ export default function LandingHero() {
                   className={`mt-2 overflow-hidden transition-all duration-300 ${openIndex === idx ? "max-h-96" : "max-h-0"}`}
                   aria-hidden={openIndex !== idx}
                 >
-                  <p className="text-left text-base sm:text-lg text-gray-300 pb-2">
+                  <p className="text-left text-base sm:text-lg text-gray-700 dark:text-gray-300 pb-2">
                     {a}
                   </p>
                 </dd>
@@ -361,7 +361,7 @@ export default function LandingHero() {
                 type="text"
                 id="name"
                 name="name"
-                className="mt-2 w-full rounded-md border border-gray-600 bg-neutral-800 p-2 text-gray-200 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="mt-2 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-neutral-800 p-2 text-gray-800 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 placeholder="Your name"
               />
             </div>
@@ -373,7 +373,7 @@ export default function LandingHero() {
                 type="email"
                 id="email"
                 name="email"
-                className="mt-2 w-full rounded-md border border-gray-600 bg-neutral-800 p-2 text-gray-200 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="mt-2 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-neutral-800 p-2 text-gray-800 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 placeholder="you@example.com"
               />
             </div>
@@ -385,7 +385,7 @@ export default function LandingHero() {
                 id="message"
                 name="message"
                 rows="5"
-                className="mt-2 w-full rounded-md border border-gray-600 bg-neutral-800 p-2 text-gray-200 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="mt-2 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-neutral-800 p-2 text-gray-800 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 placeholder="Your message"
               ></textarea>
             </div>
@@ -399,18 +399,18 @@ export default function LandingHero() {
               </button>
             </div>
           </form>
-          <p className="mt-4 text-left text-sm text-gray-500">
+          <p className="mt-4 text-left text-sm text-gray-600 dark:text-gray-500">
             <strong>Disclaimer:</strong> Keystone Notary Group, LLC is not a law
             firm and does not provide legal advice, guidance on document
             selection, or assistance in preparing legal documents. For questions
             about what type of document you need, please consult a licensed
             attorney.
           </p>
-          <p className="mt-8 text-sm text-gray-400 sm:mt-10">
+          <p className="mt-8 text-sm text-gray-600 dark:text-gray-400 sm:mt-10">
             Please mention the type of document or notarization service you are
             requesting.
           </p>
-          <div className="mt-4 space-y-2 text-base sm:text-lg text-gray-300">
+          <div className="mt-4 space-y-2 text-base sm:text-lg text-gray-700 dark:text-gray-300">
             <p>
               <strong>Phone:</strong>{" "}
               <a

--- a/src/components/LandingHero.test.js
+++ b/src/components/LandingHero.test.js
@@ -46,3 +46,10 @@ test("includes request notary button", () => {
     screen.getByRole("link", { name: /request notary/i })
   ).toBeInTheDocument();
 });
+
+test("contact form fields have light and dark styles", () => {
+  render(<LandingHero />);
+  const nameInput = screen.getByPlaceholderText(/your name/i);
+  expect(nameInput.className).toMatch(/bg-white/);
+  expect(nameInput.className).toMatch(/dark:bg-neutral-800/);
+});


### PR DESCRIPTION
## Summary
- improve visibility of the logo across themes
- fix FAQ item header text in light mode
- lighten contact form inputs when light theme is active

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_686681c805bc83278a340e5a4670794b