### PR TITLE
Add Leaflet service area map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "framer-motion": "^12.23.0",
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet": "^6.1.0",
@@ -11245,6 +11246,12 @@
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^6.30.1",
+    "leaflet": "^1.9.4",
     "react-scripts": "^5.0.1"
   },
   "overrides": {

--- a/src/components/ServiceAreaMap.jsx
+++ b/src/components/ServiceAreaMap.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+/**
+ * Displays an interactive map showing the notary service area.
+ * Utilizes Leaflet with OpenStreetMap tiles.
+ */
+export default function ServiceAreaMap() {
+  useEffect(() => {
+    const map = L.map('service-area-map', {
+      attributionControl: false,
+      zoomControl: false,
+    }).setView([40.2765, -75.1449], 9); // Centered on Bucks/Montgomery County, PA
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(map);
+
+    return () => {
+      map.remove();
+    };
+  }, []);
+
+  return (
+    <div
+      id="service-area-map"
+      className="h-64 w-full rounded-md shadow-inner"
+      role="img"
+      aria-label="Service area map"
+    />
+  );
+}

--- a/src/components/ServiceAreaMap.test.js
+++ b/src/components/ServiceAreaMap.test.js
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import ServiceAreaMap from './ServiceAreaMap.jsx';
+
+test('renders map container', () => {
+  const { container } = render(<ServiceAreaMap />);
+  expect(container.querySelector('#service-area-map')).toBeInTheDocument();
+});

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import LayoutWrapper from "../components/LayoutWrapper";
 import PageTransition from "../components/PageTransition";
+import ServiceAreaMap from "../components/ServiceAreaMap";
 import { motion } from "framer-motion";
 
 export default function ContactPage() {
@@ -220,6 +221,9 @@ export default function ContactPage() {
               {node}
             </motion.p>
           ))}
+        </div>
+        <div className="mt-8">
+          <ServiceAreaMap />
         </div>
         {/* Decorative feather watermark */}
         <svg

--- a/src/pages/contact.test.js
+++ b/src/pages/contact.test.js
@@ -79,3 +79,13 @@ test('shows validation error for invalid email', () => {
   expect(fetch).not.toHaveBeenCalled();
   expect(screen.getByText(/enter a valid email/i)).toBeInTheDocument();
 });
+
+test('renders service area map', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <ContactPage />
+    </MemoryRouter>
+  );
+
+  expect(container.querySelector('#service-area-map')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- install Leaflet
- create `ServiceAreaMap` component with OpenStreetMap tiles
- display map under contact information
- test the new component and update contact tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68668c92400883278c40980a781645ee