### PR TITLE
Fix scroll progress delay

### DIFF
--- a/src/components/ScrollProgress.jsx
+++ b/src/components/ScrollProgress.jsx
@@ -2,39 +2,25 @@ import React, { useEffect, useState } from 'react';
 
 export default function ScrollProgress() {
   const [progress, setProgress] = useState(0);
-  const [target, setTarget] = useState(0);
 
   useEffect(() => {
     const handleScroll = () => {
       const scrollTop = window.scrollY;
       const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-      setTarget(docHeight > 0 ? (scrollTop / docHeight) * 100 : 0);
+      const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      setProgress(pct);
     };
 
-    window.addEventListener('scroll', handleScroll);
+    // Use passive scroll listener for better performance
+    window.addEventListener('scroll', handleScroll, { passive: true });
     handleScroll();
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Smooth progress bar updates using requestAnimationFrame
-  useEffect(() => {
-    let raf;
-    const animate = () => {
-      setProgress((prev) => {
-        const diff = target - prev;
-        if (Math.abs(diff) < 0.1) return target;
-        return prev + diff * 0.1;
-      });
-      raf = requestAnimationFrame(animate);
-    };
-    raf = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(raf);
-  }, [target]);
-
   return (
     <div
       aria-hidden="true"
-      className="fixed top-0 left-0 z-[60] h-1 bg-blue-500 transition-[width] duration-500 ease-in-out"
+      className="fixed top-0 left-0 z-[60] h-1 bg-blue-500 transition-[width] duration-150 ease-out"
       style={{ width: `${progress}%` }}
     />
   );


### PR DESCRIPTION
## Summary
- simplify `ScrollProgress` logic
- use passive scroll listener for smoother updates
- shorten CSS transition duration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866c39f0b1483278a5b0cc7ab6e2ead