### PR TITLE
Fix npm audit issues and update dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "css-select": "^5.1.0",
     "nth-check": "^2.1.1",
     "resolve-url-loader": "^5.0.0",
-    "postcss": "^8.5.6"
+    "postcss": "^8.5.6",
+    "webpack-dev-server": "^4.15.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary
- update `webpack-dev-server` override to 4.15.2 to address audit warning
- run `npm install`, `npm test`, and `npm run build`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6866cdbd94108327bf14e96ab322ec8c