### PR TITLE
Remove stray closing script tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -96,7 +96,6 @@
       gtag('js', new Date());
       gtag('config', 'G-XXXXXXXXXX');
     </script>
-      </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
     <script>


### PR DESCRIPTION
## Summary
- clean up stray closing script tag in `public/index.html`

## Testing
- `npx --yes htmlhint public/index.html`
- `npm test --silent </dev/null`

------
https://chatgpt.com/codex/tasks/task_b_6866ef93cdb4832790e0b3dca13203a0