### PR TITLE
Update sitemap test to avoid full build

### DIFF
--- a/src/sitemap.test.js
+++ b/src/sitemap.test.js
@@ -4,11 +4,12 @@ import { execSync } from 'child_process';
 
 describe('sitemap generation', () => {
   beforeAll(() => {
-    execSync('npm run build', { stdio: 'inherit' });
-  }, 300000); // allow up to 5 minutes for build
+    // Generate sitemap without running the full build for faster tests
+    execSync('node scripts/generate-sitemap.js', { stdio: 'inherit' });
+  });
 
-  test('sitemap.xml exists in build directory', () => {
-    const sitemapPath = path.join(__dirname, '..', 'build', 'sitemap.xml');
+  test('sitemap.xml exists in public directory', () => {
+    const sitemapPath = path.join(__dirname, '..', 'public', 'sitemap.xml');
     expect(fs.existsSync(sitemapPath)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- run `generate-sitemap.js` directly in sitemap test
- check for generated file in `public/`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6866f0beee9883279b2ed5cf9a0339d0