### PR TITLE
Fix trailing slash in sitemap URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This project uses npm overrides to pin certain transitive dependencies to secure
 **Note**: The `SITEMAP_BASE_URL` environment variable controls the base URL
 used in `public/sitemap.xml`. Set this variable before running
 `npm run build` or `npm run generate-sitemap` to ensure links point to the
-correct domain.
+correct domain. Any trailing slash will be removed automatically so either
+`https://example.com` or `https://example.com/` work the same.
 
 ## Project Structure
 

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -18,7 +18,9 @@ function getRoutes() {
 }
 
 function generateSitemap(routes) {
-  const base = process.env.SITEMAP_BASE_URL || 'http://localhost';
+  const rawBase = process.env.SITEMAP_BASE_URL || 'http://localhost';
+  // Remove any trailing slash to avoid double slashes in URLs
+  const base = rawBase.replace(/\/$/, '');
   const urls = routes.map(r => {
     const loc = r === '/' ? base : `${base}${r}`;
     return `  <url><loc>${loc}</loc></url>`;

--- a/src/sitemap.test.js
+++ b/src/sitemap.test.js
@@ -12,4 +12,15 @@ describe('sitemap generation', () => {
     const sitemapPath = path.join(__dirname, '..', 'public', 'sitemap.xml');
     expect(fs.existsSync(sitemapPath)).toBe(true);
   });
+
+  test('removes trailing slash from base URL', () => {
+    execSync('node scripts/generate-sitemap.js', {
+      stdio: 'inherit',
+      env: { ...process.env, SITEMAP_BASE_URL: 'https://example.com/' },
+    });
+
+    const sitemapPath = path.join(__dirname, '..', 'public', 'sitemap.xml');
+    const xml = fs.readFileSync(sitemapPath, 'utf8');
+    expect(xml).toContain('<loc>https://example.com/about</loc>');
+  });
 });


### PR DESCRIPTION
## Summary
- trim trailing slash from `SITEMAP_BASE_URL` in sitemap generator
- document automatic trailing-slash removal in README
- add unit test ensuring sitemap base URL does not create double slashes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6866f8029f5c83279e8f850a1d83f366