### PR TITLE
Upgrade to react-helmet-async

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ correct domain. Any trailing slash will be removed automatically so either
 
 - `src/` - React components and pages
 - `public/` - Static assets and HTML template
+- `react-helmet-async` manages document head tags via a provider in `src/index.js`
 
 ## Analytics
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,5 +3,5 @@
 - [ ] Test the site across modern browsers to confirm Tailwind v4 and React 19 behave as expected
 - [ ] Review service worker caching strategy and update `CACHE_NAME` if assets change
 - [ ] Confirm Google Analytics ID injection still works after build
-- [ ] Consider migrating from `react-helmet` to `react-helmet-async` for better async support
+- [x] Consider migrating from `react-helmet` to `react-helmet-async` for better async support
 - [ ] Update README with any new build or deployment instructions once migration is complete

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "framer-motion": "^12.23.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-helmet": "^6.1.0",
+        "react-helmet-async": "^2.0.5",
         "react-router-dom": "^7.6.3",
         "react-scripts": "^5.0.1"
       },
@@ -9723,6 +9723,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -14777,28 +14786,18 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
     },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "license": "MIT",
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/react-helmet/node_modules/react-side-effect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {
@@ -15853,6 +15852,12 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "framer-motion": "^12.23.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-helmet": "^6.1.0",
+    "react-helmet-async": "^2.0.5",
     "react-router-dom": "^7.6.3",
     "react-scripts": "^5.0.1"
   },

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 
 test('renders Keystone Notary Group heading', () => {
-  render(<App />);
+  render(
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
+  );
   const heading = screen.getByRole('heading', {
     level: 1,
     name: /keystone notary group/i,
@@ -11,7 +16,11 @@ test('renders Keystone Notary Group heading', () => {
 });
 
 test('includes about section', () => {
-  render(<App />);
+  render(
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
+  );
   const about = screen.getByRole('region', { name: /about/i });
   expect(about).toBeInTheDocument();
 });

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Helmet } from "react-helmet";
+import { Helmet } from "react-helmet-async";
 import Header from "./Header";
 import Footer from "./Footer";
 import Certifications from "./Certifications";

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { HelmetProvider } from "react-helmet-async";
 import { register as registerServiceWorker } from "./serviceWorkerRegistration";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
   </React.StrictMode>
 );
 

--- a/src/pages/contact.test.js
+++ b/src/pages/contact.test.js
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import ContactPage from './contact.jsx';
 
 beforeEach(() => {
@@ -12,9 +13,11 @@ afterEach(() => {
 
 test('submits form and shows confirmation message', async () => {
   render(
-    <MemoryRouter>
-      <ContactPage />
-    </MemoryRouter>
+    <HelmetProvider>
+      <MemoryRouter>
+        <ContactPage />
+      </MemoryRouter>
+    </HelmetProvider>
   );
 
   fireEvent.change(screen.getByLabelText(/full name/i), {
@@ -44,9 +47,11 @@ test('submits form and shows confirmation message', async () => {
 
 test('shows validation errors for empty fields', () => {
   render(
-    <MemoryRouter>
-      <ContactPage />
-    </MemoryRouter>
+    <HelmetProvider>
+      <MemoryRouter>
+        <ContactPage />
+      </MemoryRouter>
+    </HelmetProvider>
   );
 
   fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -59,9 +64,11 @@ test('shows validation errors for empty fields', () => {
 
 test('shows validation error for invalid email', () => {
   render(
-    <MemoryRouter>
-      <ContactPage />
-    </MemoryRouter>
+    <HelmetProvider>
+      <MemoryRouter>
+        <ContactPage />
+      </MemoryRouter>
+    </HelmetProvider>
   );
 
   fireEvent.change(screen.getByLabelText(/full name/i), {

--- a/src/pages/faq.test.js
+++ b/src/pages/faq.test.js
@@ -1,12 +1,15 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import FaqPage from './faq.jsx';
 
 test('accordion shows one answer at a time', () => {
   render(
-    <MemoryRouter>
-      <FaqPage />
-    </MemoryRouter>
+    <HelmetProvider>
+      <MemoryRouter>
+        <FaqPage />
+      </MemoryRouter>
+    </HelmetProvider>
   );
 
   const firstButton = screen.getByRole('button', {
@@ -37,9 +40,11 @@ test('accordion shows one answer at a time', () => {
 
 test('CTA to contact page is present', () => {
   render(
-    <MemoryRouter>
-      <FaqPage />
-    </MemoryRouter>
+    <HelmetProvider>
+      <MemoryRouter>
+        <FaqPage />
+      </MemoryRouter>
+    </HelmetProvider>
   );
 
   expect(


### PR DESCRIPTION
## Summary
- replace deprecated `react-helmet` with `react-helmet-async`
- wrap the app with `HelmetProvider`
- update tests for the new provider
- document the new head manager
- mark migration complete in TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68670f09c9348327b670725a8972d2a9