### PR TITLE
Add sitemap script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ section but are disabled by default.
 This project uses npm overrides to pin certain transitive dependencies to secure versions.
 
 1. Install dependencies: `npm install`
-   - This runs `patch-package` to apply local patches in the `patches/` directory.
 2. Start the development server: `npm start`
 3. Build for production: `npm run build`
-4. Run tests: `npm test`
+4. Generate the sitemap: `npm run generate-sitemap`
+5. Run tests: `npm test`
 
 **Note**: The `SITEMAP_BASE_URL` environment variable controls the base URL
 used in `public/sitemap.xml`. Set this variable before running

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "generate-sitemap": "node scripts/generate-sitemap.js",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `generate-sitemap` npm script
- document the new script and remove outdated patch-package note

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68680eb710108327a76014b0734201e9