### PR TITLE
Fix home page container width

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -6,7 +6,8 @@ import PageTransition from "../components/PageTransition";
 export default function HomePage() {
   return (
     <PageTransition>
-      <LayoutWrapper fullWidth>
+      {/* Use default responsive container for consistent layout */}
+      <LayoutWrapper>
         <LandingHero />
       </LayoutWrapper>
     </PageTransition>


### PR DESCRIPTION
## Summary
- remove `fullWidth` from `HomePage` layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686857c5ade083278a544313db9fa672