### PR TITLE
Fix responsive overflow in header and sections

### DIFF
--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Certifications() {
   return (
-    <section className="bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24">
+    <section className="bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 max-w-screen-md mx-auto px-4">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <h2 className="mb-8 text-center">
           Certifications & Credentials

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -75,7 +75,7 @@ export default function Header() {
       }`}
     >
       <h1 className="sr-only">Keystone Notary Group</h1>
-      <div className="w-full px-4 sm:px-6 md:px-8 max-w-screen-lg mx-auto flex justify-between items-center">
+      <div className="w-full max-w-screen-lg mx-auto px-4 py-2 flex justify-between items-center">
         {/* Theme toggle button */}
         <button
           type="button"

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -71,7 +71,7 @@ export default function LandingHero() {
       <section
         id="home"
         ref={homeRef}
-        className={`relative flex min-h-dvh max-w-full flex-col items-center justify-center bg-white text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 overflow-hidden overflow-x-hidden py-12 sm:py-16 md:py-20 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative flex min-h-dvh max-w-full flex-col items-center justify-center bg-white text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 overflow-hidden overflow-x-hidden py-12 sm:py-16 md:py-20 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40 motion-safe:animate-bg-pan"
@@ -132,6 +132,7 @@ export default function LandingHero() {
             Mobile Notary Services in Pennsylvania
           </motion.p>
           <motion.a
+            id="hero-request-notary"
             href="#contact"
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
@@ -171,7 +172,7 @@ export default function LandingHero() {
         id="about"
         ref={aboutRef}
         aria-label="About"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-screen-md px-4 sm:px-6 lg:px-8 text-center overflow-x-hidden">
           <h2>
@@ -212,7 +213,7 @@ export default function LandingHero() {
         id="services"
         ref={servicesRef}
         aria-label="Services"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-full max-w-screen-lg px-4 sm:px-6 lg:px-8 overflow-x-hidden">
           <h2 className="text-center">
@@ -282,7 +283,7 @@ export default function LandingHero() {
         id="faq"
         ref={faqRef}
         aria-label="Frequently Asked Questions"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
           <h2 className="text-center">
@@ -345,7 +346,7 @@ export default function LandingHero() {
         id="contact"
         ref={contactRef}
         aria-label="Contact"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden px-4 py-16 lg:py-24 sm:px-6 lg:px-8 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div className="mx-auto max-w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
           <h2 className="text-center">

--- a/src/components/RequestNotaryButton.jsx
+++ b/src/components/RequestNotaryButton.jsx
@@ -27,9 +27,19 @@ export default function RequestNotaryButton() {
     };
     window.addEventListener("focusin", focusIn);
     window.addEventListener("focusout", focusOut);
+    let observer;
+    const heroCta = document.getElementById("hero-request-notary");
+    if (heroCta) {
+      observer = new IntersectionObserver(
+        ([entry]) => setHidden(entry.isIntersecting),
+        { threshold: 0.1 }
+      );
+      observer.observe(heroCta);
+    }
     return () => {
       window.removeEventListener("focusin", focusIn);
       window.removeEventListener("focusout", focusOut);
+      observer?.disconnect();
     };
   }, []);
 

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -14,7 +14,7 @@ export default function NotFound() {
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -10 }}
           transition={{ duration: 0.4, ease: "easeOut" }}
-          className="max-w-screen-lg mx-auto overflow-x-hidden bg-black py-16 lg:py-24 text-center text-gray-200 space-y-4 sm:space-y-6"
+          className="overflow-x-hidden bg-black py-16 lg:py-24 text-center text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
         >
         <h1>404 – Page Not Found</h1>
         <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -14,7 +14,7 @@ export default function AboutPage() {
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: "easeOut" }}
             viewport={{ once: true }}
-            className="max-w-screen-lg mx-auto overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6"
+            className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
           >
         <h1 className="text-center">
           About Keystone Notary Group

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -72,7 +72,7 @@ export default function ContactPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="max-w-screen-lg mx-auto overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 paper-texture py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 scroll-mt-20"
+          className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 paper-texture py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 scroll-mt-20 max-w-screen-md mx-auto px-4"
         >
         <h1 className="text-center">
           Contact
@@ -248,7 +248,7 @@ export default function ContactPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="max-w-screen-md mx-auto overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mt-12 py-16 lg:py-24 space-y-4 sm:space-y-6"
+          className="max-w-screen-md mx-auto px-4 overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mt-12 py-16 lg:py-24 space-y-4 sm:space-y-6"
         >
           <div className="bg-neutral-900 p-6 ring-1 ring-neutral-700 shadow-[0_0_20px_rgba(255,255,255,0.05)]">
           <div className="mb-8 flex flex-row items-center justify-center">

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -45,7 +45,7 @@ export default function FaqPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="max-w-screen-lg mx-auto overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6"
+          className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
         >
         <h1 className="text-center">
           Frequently Asked Questions

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -14,7 +14,7 @@ export default function ServicesPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="max-w-screen-lg mx-auto overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6"
+          className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
         >
           <h1 className="text-center">Our Services</h1>
           <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />


### PR DESCRIPTION
## Summary
- keep nav/header container within `max-w-screen-lg`
- constrain all section layouts to `max-w-screen-md`
- hide floating `Request Notary` button when hero CTA is visible
- ensure certifications section uses same max width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68686d3718248327a3fae54e7887ed13