### PR TITLE
Fix responsive layout containers

### DIFF
--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -2,8 +2,8 @@ import React from "react";
 
 export default function Certifications() {
   return (
-    <section className="bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 max-w-screen-md mx-auto px-4">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 w-full">
+      <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
         <h2 className="mb-8 text-center">
           Certifications & Credentials
         </h2>

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -71,7 +71,7 @@ export default function LandingHero() {
       <section
         id="home"
         ref={homeRef}
-        className={`relative flex min-h-dvh max-w-full flex-col items-center justify-center bg-white text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 overflow-hidden overflow-x-hidden py-12 sm:py-16 md:py-20 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`relative flex min-h-dvh w-full flex-col items-center justify-center bg-white text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 overflow-hidden overflow-x-hidden py-12 sm:py-16 md:py-20 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${homeVisible ? "opacity-100 translate-y-0" : ""}`}
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40 motion-safe:animate-bg-pan"
@@ -108,8 +108,8 @@ export default function LandingHero() {
           <line x1="17.5" y1="15" x2="9" y2="15" />
         </svg>
 
-        <div className="mx-auto max-w-screen-lg px-4 sm:px-6 lg:px-8 overflow-x-hidden">
-          <div className="relative z-10 mx-auto flex max-w-full max-w-screen-md flex-col items-center overflow-x-hidden px-4">
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
+          <div className="relative z-10 mx-auto flex w-full flex-col items-center overflow-x-hidden">
           {/* Subtle glow behind logo */}
           <div
             aria-hidden="true"
@@ -172,9 +172,9 @@ export default function LandingHero() {
         id="about"
         ref={aboutRef}
         aria-label="About"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <div className="mx-auto max-w-screen-md px-4 sm:px-6 lg:px-8 text-center overflow-x-hidden">
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8 text-center overflow-x-hidden">
           <h2>
             About Keystone Notary Group
           </h2>
@@ -213,9 +213,9 @@ export default function LandingHero() {
         id="services"
         ref={servicesRef}
         aria-label="Services"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${servicesVisible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <div className="mx-auto max-w-full max-w-screen-lg px-4 sm:px-6 lg:px-8 overflow-x-hidden">
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
           <h2 className="text-center">
             Our Services
           </h2>
@@ -283,9 +283,9 @@ export default function LandingHero() {
         id="faq"
         ref={faqRef}
         aria-label="Frequently Asked Questions"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${faqVisible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <div className="mx-auto max-w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
           <h2 className="text-center">
             Frequently Asked Questions
           </h2>
@@ -346,9 +346,9 @@ export default function LandingHero() {
         id="contact"
         ref={contactRef}
         aria-label="Contact"
-        className={`flex min-h-dvh max-w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 max-w-screen-md mx-auto px-4 ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
+        className={`flex min-h-dvh w-full flex-col items-center justify-center bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${contactVisible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <div className="mx-auto max-w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8 overflow-x-hidden">
           <h2 className="text-center">
             Contact
           </h2>

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -11,7 +11,7 @@ import ScrollProgress from "./ScrollProgress";
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
-      className="container mx-auto scroll-smooth relative flex min-h-dvh flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px] px-4 sm:px-6 lg:px-8"
+      className="w-full scroll-smooth relative flex min-h-dvh flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px] px-4 sm:px-6 lg:px-8"
       /* Ensure pages share consistent textured background */
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -7,15 +7,15 @@ export default function NotFound() {
   return (
     <PageTransition>
       <LayoutWrapper>
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.section
           aria-label="Page not found"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -10 }}
           transition={{ duration: 0.4, ease: "easeOut" }}
-          className="overflow-x-hidden bg-black py-16 lg:py-24 text-center text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
+          className="overflow-x-hidden bg-black py-16 lg:py-24 text-center text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
         <h1>404 – Page Not Found</h1>
         <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />
         <p className="mb-8 text-base sm:text-lg text-gray-400">Sorry, the page you are looking for doesn\'t exist.</p>
@@ -27,8 +27,8 @@ export default function NotFound() {
           >
             Return Home
           </motion.a>
+          </div>
         </motion.section>
-        </div>
       </LayoutWrapper>
     </PageTransition>
   );

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -7,15 +7,15 @@ export default function AboutPage() {
   return (
     <PageTransition>
       <LayoutWrapper>
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <motion.section
-            aria-label="About"
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            viewport={{ once: true }}
-            className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
-          >
+        <motion.section
+          aria-label="About"
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          viewport={{ once: true }}
+          className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 w-full"
+        >
+          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
         <h1 className="text-center">
           About Keystone Notary Group
         </h1>
@@ -42,8 +42,8 @@ export default function AboutPage() {
         <p className="mt-10 text-left text-sm text-gray-400">
           Commissioned in the Commonwealth of Pennsylvania
         </p>
-          </motion.section>
-        </div>
+          </div>
+        </motion.section>
       </LayoutWrapper>
     </PageTransition>
   );

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -64,7 +64,6 @@ export default function ContactPage() {
   return (
     <PageTransition>
       <LayoutWrapper>
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.section
           id="contact"
           aria-label="Contact"
@@ -72,8 +71,9 @@ export default function ContactPage() {
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 paper-texture py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 scroll-mt-20 max-w-screen-md mx-auto px-4"
+          className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 paper-texture py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 scroll-mt-20 w-full"
         >
+        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
         <h1 className="text-center">
           Contact
         </h1>
@@ -238,18 +238,18 @@ export default function ContactPage() {
           <line x1="16" y1="8" x2="2" y2="22" />
           <line x1="17.5" y1="15" x2="9" y2="15" />
         </svg>
+          </div>
         </motion.section>
-        </div>
         <hr className="border-t border-gray-700 my-12" />
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.section
           aria-label="What to Bring to Your Appointment"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="max-w-screen-md mx-auto px-4 overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mt-12 py-16 lg:py-24 space-y-4 sm:space-y-6"
+          className="w-full overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mt-12 py-16 lg:py-24 space-y-4 sm:space-y-6"
         >
+          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
           <div className="bg-neutral-900 p-6 ring-1 ring-neutral-700 shadow-[0_0_20px_rgba(255,255,255,0.05)]">
           <div className="mb-8 flex flex-row items-center justify-center">
             <svg
@@ -283,9 +283,9 @@ export default function ContactPage() {
           >
             📄 Download Appointment Checklist (PDF)
           </a>
+          </div>
         </div>
         </motion.section>
-        </div>
       </LayoutWrapper>
     </PageTransition>
   );

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -38,15 +38,15 @@ export default function FaqPage() {
   return (
     <PageTransition>
       <LayoutWrapper>
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.section
           aria-label="Frequently Asked Questions"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
+          className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
+          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
         <h1 className="text-center">
           Frequently Asked Questions
         </h1>
@@ -106,9 +106,9 @@ export default function FaqPage() {
           >
             Contact Us
           </motion.a>
+          </div>
         </div>
         </motion.section>
-        </div>
       </LayoutWrapper>
     </PageTransition>
   );

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -7,15 +7,15 @@ export default function ServicesPage() {
   return (
     <PageTransition>
       <LayoutWrapper>
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <motion.section
           aria-label="Services"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           viewport={{ once: true }}
-          className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 max-w-screen-md mx-auto px-4"
+          className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
+          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
           <h1 className="text-center">Our Services</h1>
           <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />
 
@@ -73,8 +73,8 @@ export default function ServicesPage() {
           <line x1="16" y1="8" x2="2" y2="22" />
           <line x1="17.5" y1="15" x2="9" y2="15" />
         </svg>
+          </div>
         </motion.section>
-        </div>
       </LayoutWrapper>
     </PageTransition>
   );


### PR DESCRIPTION
## Summary
- remove container restrictions from LayoutWrapper and section elements
- keep inner wrappers with max-width for readability
- update all pages to use full-width sections on small screens

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68686f6ac0c483278078ad87cc9e2e5b