### PR TITLE
Fix layout container usage

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 export default function Footer() {
   return (
     <footer className="bg-neutral-800 text-gray-300 dark:bg-black dark:text-gray-500">
-      <div className="container mx-auto px-4 py-6 sm:px-6 lg:px-8">
+      <div className="w-full max-w-screen-lg mx-auto px-4 py-6 sm:px-6 lg:px-8">
         <p className="text-xs tracking-wider text-center">
           &copy; Keystone Notary Group. All rights reserved.
         </p>

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -11,7 +11,7 @@ import ScrollProgress from "./ScrollProgress";
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
-      className="w-full scroll-smooth relative flex min-h-dvh flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px] px-4 sm:px-6 lg:px-8"
+      className="w-full min-h-screen min-h-dvh bg-black dark:bg-black scroll-smooth relative flex flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px] px-4 sm:px-6 lg:px-8"
       /* Ensure pages share consistent textured background */
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -9,8 +9,9 @@
   }
   /* Global background pattern */
   html,
-  body {
-    @apply overflow-x-hidden;
+  body,
+  #root {
+    @apply w-[100vw] min-w-0 max-w-[100vw] m-0 p-0 overflow-x-hidden;
   }
 
   body {
@@ -40,12 +41,6 @@
   }
 }
 
-/* Basic body defaults */
-body {
-  overflow-x: hidden;
-  margin: 0;
-  padding: 0;
-}
 @layer utilities {
   .font-display {
     font-family: var(--font-display);


### PR DESCRIPTION
## Summary
- ensure global html/body take full width to avoid page constraints
- apply `bg-black` and min-h-screen to LayoutWrapper outer wrapper
- replace footer `container` class with responsive max-w wrapper

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686874faaa908327a15fd2885515f3df