### PR TITLE
Audit layout wrappers for width classes

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 export default function Footer() {
   return (
-    <footer className="bg-neutral-800 text-gray-300 dark:bg-black dark:text-gray-500">
+    <footer className="w-full bg-neutral-800 text-gray-300 dark:bg-black dark:text-gray-500">
       <div className="w-full max-w-screen-lg mx-auto px-4 py-6 sm:px-6 lg:px-8">
         <p className="text-xs tracking-wider text-center">
           &copy; Keystone Notary Group. All rights reserved.

--- a/src/components/LegalFooter.jsx
+++ b/src/components/LegalFooter.jsx
@@ -3,7 +3,7 @@ import React from "react";
 /** Slim footer row for legal notices */
 export default function LegalFooter() {
   return (
-    <div className="bg-black text-xs text-gray-500 py-4 text-center">
+    <div className="w-full bg-black text-xs text-gray-500 py-4 text-center">
       <p>Licensed & Bonded Notary Public – Pennsylvania</p>
       <p>Copyright © Keystone Notary Group 2025</p>
     </div>


### PR DESCRIPTION
## Summary
- add `w-full` to Footer and LegalFooter wrappers so outer sections are full width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686876ac5adc83279abb69721c4102d9