### PR TITLE
Fix global overflow & layout wrapper

### DIFF
--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -11,7 +11,7 @@ import ScrollProgress from "./ScrollProgress";
 export default function LayoutWrapper({ children, fullWidth = false }) {
   return (
     <div
-      className="w-full min-h-screen min-h-dvh bg-black dark:bg-black scroll-smooth relative flex flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px] px-4 sm:px-6 lg:px-8"
+      className="w-full min-h-screen min-h-dvh bg-black dark:bg-black scroll-smooth relative flex flex-col overflow-x-hidden brightness-100 contrast-100 text-gray-900 dark:brightness-125 dark:contrast-110 dark:text-gray-200 before:absolute before:inset-0 before:-z-10 before:pointer-events-none before:bg-[radial-gradient(circle,rgba(255,255,255,0.05)_1px,transparent_1px)] before:bg-[length:50px_50px]"
       /* Ensure pages share consistent textured background */
       style={{ backgroundImage: "url('/bg-texture.PNG')" }}
     >
@@ -111,7 +111,7 @@ export default function LayoutWrapper({ children, fullWidth = false }) {
         {fullWidth ? (
           children
         ) : (
-          <div className="w-full min-h-screen mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="w-full max-w-screen-md mx-auto min-h-screen px-4 sm:px-6 lg:px-8">
             {children}
           </div>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,12 @@
   html,
   body,
   #root {
-    @apply w-[100vw] min-w-0 max-w-[100vw] m-0 p-0 overflow-x-hidden;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    min-width: 0 !important;
+    overflow-x: hidden !important;
+    margin: 0;
+    padding: 0;
   }
 
   body {


### PR DESCRIPTION
## Summary
- remove padding from LayoutWrapper outer wrapper
- keep inner wrapper centered with padding and max width
- add CSS overflow guard for html and body

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68687b7c4a1c83278264d01e39bac1eb