### PR TITLE
Update mobile menu style and add safe area insets

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -120,7 +120,7 @@ export default function Header() {
                 animate={{ x: 0 }}
                 exit={{ x: '100%' }}
                 transition={{ type: 'tween', duration: 0.3 }}
-                className="fixed right-0 top-0 bottom-0 w-[80vw] max-w-xs min-w-[200px] bg-white text-gray-800 dark:bg-gray-900 dark:text-white shadow-xl"
+                className="fixed right-0 top-0 bottom-0 w-screen max-w-full bg-white text-gray-800 dark:bg-gray-900 dark:text-white shadow-xl"
               >
             <button
               type="button"

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,8 @@
     overflow-x: hidden !important;
     margin: 0;
     padding: 0;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
   }
 
   body {


### PR DESCRIPTION
## Summary
- adjust mobile navigation panel width
- add iOS safe-area inset padding to html/body/root

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686880bbe65c8327ba6284c73934870f