### PR TITLE
Update home page test layout

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,12 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App.jsx';
 
-test('renders Keystone Notary Group heading', () => {
+test('renders UNBOXED TEST heading', () => {
   render(
     <HelmetProvider>
       <App />
     </HelmetProvider>
   );
-  const heading = screen.getByRole('heading', { name: /keystone notary group/i, level: 1 });
+  const heading = screen.getByRole('heading', { name: /unboxed test/i, level: 1 });
   expect(heading).toBeInTheDocument();
 });

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,15 +1,8 @@
-import React from "react";
-import LayoutWrapper from "../components/LayoutWrapper";
-import LandingHero from "../components/LandingHero";
-import PageTransition from "../components/PageTransition";
-
-export default function HomePage() {
+export default function Index() {
   return (
-    <PageTransition>
-      {/* Use default responsive container for consistent layout */}
-      <LayoutWrapper>
-        <LandingHero />
-      </LayoutWrapper>
-    </PageTransition>
+    <div className="w-full min-h-screen bg-green-500 text-white flex flex-col items-center justify-center">
+      <h1 className="text-5xl font-bold">UNBOXED TEST</h1>
+      <p className="mt-6 text-xl">This should fill your whole screen. If it’s boxed, the problem is NOT your code!</p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the home page with a green fullscreen test layout
- update `App.test.jsx` to match new heading

## Testing
- `npm test`
- `npm run build`
- `npx vercel --prod --confirm` *(fails: Need to install the following packages: vercel@44.2.12)*

------
https://chatgpt.com/codex/tasks/task_b_68688b813c0c832798bb51fc9bbdccaf