### PR TITLE
Fix homepage layout

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -29,7 +29,7 @@
   </head>
   <body>
     <main>
-      <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="w-full max-w-screen-md mx-auto px-4 sm:px-6 lg:px-8">
         <h1>You're offline</h1>
         <p>Please check your internet connection and try again.</p>
       </div>

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -10,8 +10,9 @@ import ScrollProgress from "./ScrollProgress";
 
 export default function LayoutWrapper({ children }) {
   return (
+    <div className="w-screen min-h-screen overflow-x-hidden">
       <div
-        className="w-full min-h-screen bg-black flex flex-col overflow-x-hidden"
+        className="flex flex-col w-full min-h-screen bg-black"
         style={{ backgroundImage: "url('/bg-texture.PNG')" }}
       >
       <ScrollProgress />
@@ -115,6 +116,7 @@ export default function LayoutWrapper({ children }) {
       {/* Floating quick access button for mobile devices */}
       <RequestNotaryButton />
       <BackToTopButton />
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -60,3 +60,22 @@
     background-position: 0 0, 2px 2px;
   }
 }
+
+html,
+body,
+#root {
+  width: 100vw !important;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+  background: #171717;
+}
+@supports (padding: env(safe-area-inset-left)) {
+  body {
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,8 +1,14 @@
-export default function Index() {
+import React from "react";
+import LayoutWrapper from "../components/LayoutWrapper";
+import LandingHero from "../components/LandingHero";
+import PageTransition from "../components/PageTransition";
+
+export default function HomePage() {
   return (
-    <div className="w-full min-h-screen bg-green-500 text-white flex flex-col items-center justify-center">
-      <h1 className="text-5xl font-bold">UNBOXED TEST</h1>
-      <p className="mt-6 text-xl">This should fill your whole screen. If it’s boxed, the problem is NOT your code!</p>
-    </div>
+    <PageTransition>
+      <LayoutWrapper>
+        <LandingHero />
+      </LayoutWrapper>
+    </PageTransition>
   );
 }


### PR DESCRIPTION
## Summary
- restore LandingHero on homepage
- enforce full-screen wrapper without max width
- normalize offline page container
- add global width/height resets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6868939bda448327814ca6e4d45bf505