### PR TITLE
Fix safe-area overflow on iOS landscape

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="w-screen min-h-screen max-w-full m-0 overflow-x-hidden">
+<html lang="en" class="w-full min-h-screen max-w-full m-0 overflow-x-hidden">
   <head>
     <title>Keystone Notary Group – Mobile Notary Services in Pennsylvania</title>
     <meta name="description" content="Professional mobile notary serving individuals, attorneys, and financial institutions across Pennsylvania. After-hours and emergency appointments available." />
@@ -122,8 +122,8 @@
     </script>
     -->
   </head>
-  <body class="w-screen min-h-screen max-w-full m-0 scroll-smooth overflow-x-hidden text-gray-200 bg-[#171717]">
-    <div id="root" class="w-screen min-h-screen max-w-full m-0 overflow-x-hidden"></div>
+  <body class="w-full min-h-screen max-w-full m-0 scroll-smooth overflow-x-hidden text-gray-200 bg-[#171717]">
+    <div id="root" class="w-full min-h-screen max-w-full m-0 overflow-x-hidden"></div>
       <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -10,7 +10,7 @@ import ScrollProgress from "./ScrollProgress";
 
 export default function LayoutWrapper({ children }) {
   return (
-    <div className="w-screen min-h-screen overflow-x-hidden">
+    <div className="w-full min-h-screen overflow-x-hidden">
       <div
         className="flex flex-col w-full min-h-screen bg-black"
         style={{ backgroundImage: "url('/bg-texture.PNG')" }}

--- a/src/index.css
+++ b/src/index.css
@@ -11,8 +11,8 @@
   html,
   body,
   #root {
-    width: 100vw;
-    max-width: 100vw;
+    width: 100%;
+    max-width: 100%;
     min-height: 100vh;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## Summary
- set root elements to `w-full` instead of `w-screen`
- update `LayoutWrapper` container width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686897c3e2088327bda5298d8abbdb3f