### PR TITLE
Remove width constraints from wrappers

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -29,7 +29,7 @@
   </head>
   <body>
     <main>
-      <div class="w-full max-w-screen-md mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="w-full px-4 sm:px-6 lg:px-8">
         <h1>You're offline</h1>
         <p>Please check your internet connection and try again.</p>
       </div>

--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function Certifications() {
   return (
     <section className="bg-gray-100 paper-texture text-gray-800 dark:bg-gray-950 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 w-full">
-      <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+      <div className="w-full px-4 sm:px-6 lg:px-8">
         <h2 className="mb-8 text-center">
           Certifications & Credentials
         </h2>

--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -174,7 +174,7 @@ export default function LandingHero() {
         aria-label="About"
         className={`flex min-h-dvh w-full flex-col items-center justify-center bg-gray-100 text-gray-800 dark:bg-neutral-900 dark:text-gray-200 overflow-x-hidden py-16 lg:py-24 opacity-0 translate-y-[10px] transition-all duration-700 ease-in-out scroll-mt-20 ${aboutVisible ? "opacity-100 translate-y-0" : ""}`}
       >
-        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8 text-center overflow-x-hidden">
+        <div className="w-full px-4 sm:px-6 lg:px-8 text-center overflow-x-hidden">
           <h2>
             About Keystone Notary Group
           </h2>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -15,7 +15,7 @@ export default function NotFound() {
           transition={{ duration: 0.4, ease: "easeOut" }}
           className="overflow-x-hidden bg-black py-16 lg:py-24 text-center text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
-        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+        <div className="w-full px-4 sm:px-6 lg:px-8">
         <h1>404 – Page Not Found</h1>
         <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />
         <p className="mb-8 text-base sm:text-lg text-gray-400">Sorry, the page you are looking for doesn\'t exist.</p>

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -15,7 +15,7 @@ export default function AboutPage() {
           viewport={{ once: true }}
           className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
-          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+          <div className="w-full px-4 sm:px-6 lg:px-8">
         <h1 className="text-center">
           About Keystone Notary Group
         </h1>

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -73,7 +73,7 @@ export default function ContactPage() {
           viewport={{ once: true }}
           className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 paper-texture py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 scroll-mt-20 w-full"
         >
-        <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+        <div className="w-full px-4 sm:px-6 lg:px-8">
         <h1 className="text-center">
           Contact
         </h1>
@@ -249,7 +249,7 @@ export default function ContactPage() {
           viewport={{ once: true }}
           className="w-full overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 mt-12 py-16 lg:py-24 space-y-4 sm:space-y-6"
         >
-          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+          <div className="w-full px-4 sm:px-6 lg:px-8">
           <div className="bg-neutral-900 p-6 ring-1 ring-neutral-700 shadow-[0_0_20px_rgba(255,255,255,0.05)]">
           <div className="mb-8 flex flex-row items-center justify-center">
             <svg

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -46,7 +46,7 @@ export default function FaqPage() {
           viewport={{ once: true }}
           className="overflow-x-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
-          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+          <div className="w-full px-4 sm:px-6 lg:px-8">
         <h1 className="text-center">
           Frequently Asked Questions
         </h1>

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -15,7 +15,7 @@ export default function ServicesPage() {
           viewport={{ once: true }}
           className="overflow-x-hidden relative overflow-hidden bg-gradient-to-b from-neutral-900 via-black to-neutral-950 py-16 lg:py-24 text-gray-200 space-y-4 sm:space-y-6 w-full"
         >
-          <div className="mx-auto w-full max-w-screen-md px-4 sm:px-6 lg:px-8">
+          <div className="w-full px-4 sm:px-6 lg:px-8">
           <h1 className="text-center">Our Services</h1>
           <div aria-hidden="true" className="border-b-2 border-blue-500 w-12 mx-auto mb-6" />
 


### PR DESCRIPTION
## Summary
- removed `mx-auto` and `max-w-screen-md` from layout wrappers so sections span the full width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68689b3565a083278cd0f4c95e53c592