### PR TITLE
Fix full width layout

### DIFF
--- a/src/components/LandingHero.jsx
+++ b/src/components/LandingHero.jsx
@@ -27,7 +27,7 @@ export default function LandingHero() {
       }`}
     >
       <section
-        className="relative flex min-h-dvh w-full flex-col items-center justify-center overflow-hidden bg-white py-12 text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 sm:py-16 md:py-20 lg:py-24"
+        className="relative flex min-h-dvh w-full flex-col items-center justify-center overflow-hidden bg-white pt-0 pb-12 text-gray-800 dark:bg-gradient-to-b dark:from-gray-900 dark:via-gray-950 dark:to-black dark:text-gray-200 sm:pb-16 md:pb-20 lg:pb-24"
       >
         <div
           className="absolute inset-0 z-0 bg-cover bg-center opacity-40 motion-safe:animate-bg-pan"

--- a/src/components/LayoutWrapper.jsx
+++ b/src/components/LayoutWrapper.jsx
@@ -110,7 +110,8 @@ export default function LayoutWrapper({ children }) {
         </script>
       </Helmet>
       <Header />
-      <main role="main" className="flex-grow pt-20 pb-20 w-full">
+      {/* Offset content just below the fixed header */}
+      <main role="main" className="flex-grow w-full pt-16">
         {children}
       </main>
       <Certifications />

--- a/src/index.css
+++ b/src/index.css
@@ -17,11 +17,9 @@
     margin: 0;
     padding: 0;
   }
+  /* Remove safe-area padding to allow full-bleed layout */
   #root {
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
+    padding: 0;
   }
 
   body {


### PR DESCRIPTION
## Summary
- remove safe-area padding on `#root`
- tighten main content top offset
- start hero directly under the navbar

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6868a699fb408327bd3858ad49e99b74