### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,14 +92,16 @@
     
     <script>
         tailwind.config = {
+            darkMode: 'class',
             theme: {
                 extend: {
                     colors: {
                         charcoal: '#333333',
                         platinum: '#E5E5E5',
                         lightgray: '#F5F5F5',
-                        mediumgray: '#AAAAAA',
-                        darkgray: '#555555',
+                        mediumgray: '#888888',
+                        darkgray: '#444444',
+                        darkbg: '#1a1a1a'
                     },
                     fontFamily: {
                         'montserrat': ['Montserrat', 'sans-serif'],
@@ -116,7 +118,7 @@
     <style type="text/tailwindcss">
         @layer base {
             body {
-                @apply font-montserrat bg-lightgray;
+                @apply font-montserrat bg-lightgray text-charcoal dark:bg-darkbg dark:text-platinum;
             }
             .bg-charcoal {
                 background-color: #333333;
@@ -134,10 +136,10 @@
                 background-color: #F5F5F5;
             }
             .text-darkgray {
-                color: #555555;
+                color: #444444;
             }
             .border-mediumgray {
-                border-color: #AAAAAA;
+                border-color: #888888;
             }
         }
     </style>
@@ -147,6 +149,10 @@
             color: #333333;
             line-height: 1.5;
             font-size: 16px;
+        }
+        html.dark body {
+            background-color: #1a1a1a;
+            color: #E5E5E5;
         }
         
         /* Fix for input fields */
@@ -158,6 +164,13 @@
             font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             font-size: 16px;
             color: #333333;
+        }
+        html.dark input,
+        html.dark select,
+        html.dark textarea {
+            background-color: #333333;
+            color: #E5E5E5;
+            border-color: #888888;
         }
         
         /* Fallback styles in case Tailwind doesn't load properly */
@@ -257,13 +270,22 @@
         .text-charcoal, [class*="text-charcoal"] {
             color: #333333 !important;
         }
-        
+        html.dark .text-charcoal, html.dark [class*="text-charcoal"] {
+            color: #E5E5E5 !important;
+        }
+
         .bg-lightgray, [class*="bg-lightgray"] {
             background-color: #F5F5F5 !important;
         }
-        
+        html.dark .bg-lightgray, html.dark [class*="bg-lightgray"] {
+            background-color: #2b2b2b !important;
+        }
+
         .text-darkgray, [class*="text-darkgray"] {
-            color: #555555 !important;
+            color: #444444 !important;
+        }
+        html.dark .text-darkgray, html.dark [class*="text-darkgray"] {
+            color: #CCCCCC !important;
         }
         
         .bg-platinum, [class*="bg-platinum"] {
@@ -282,10 +304,17 @@
         nav {
             background-color: white;
         }
+        html.dark nav {
+            background-color: #1a1a1a;
+        }
         
         .hero-section {
             background-color: #333333;
             color: white;
+        }
+        html.dark .hero-section {
+            background-color: #1a1a1a;
+            color: #E5E5E5;
         }
         .micro-texture {
             background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23999999' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
@@ -331,6 +360,9 @@
             left: 0;
             background-color: #333333;
             transition: width 0.3s ease;
+        }
+        html.dark .nav-link::after {
+            background-color: #E5E5E5;
         }
         .nav-link:hover::after {
             width: 100%;
@@ -548,16 +580,32 @@
                     </div>
                     <span class="text-xl font-semibold tracking-wide text-charcoal">KEYSTONE NOTARY GROUP</span>
                 </div>
-                <div class="hidden md:flex space-x-8">
+                <div class="hidden md:flex items-center space-x-8">
                     <a href="#" class="nav-link text-darkgray hover:text-charcoal transition-colors duration-300 font-medium">Home</a>
                     <a href="#services" class="nav-link text-darkgray hover:text-charcoal transition-colors duration-300 font-medium">Services</a>
                     <a href="#why-choose-us" class="nav-link text-darkgray hover:text-charcoal transition-colors duration-300 font-medium">Why Us</a>
                     <a href="#about" class="nav-link text-darkgray hover:text-charcoal transition-colors duration-300 font-medium">About</a>
                     <a href="#faq" class="nav-link text-darkgray hover:text-charcoal transition-colors duration-300 font-medium">FAQ</a>
                     <a href="#contact" class="nav-link text-darkgray hover:text-charcoal transition-colors duration-300 font-medium">Contact</a>
+                    <button id="theme-toggle" class="ml-4 text-charcoal dark:text-platinum focus:outline-none" aria-label="Toggle dark mode">
+                        <svg id="theme-sun" class="h-6 w-6 hidden" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M12 18a6 6 0 100-12 6 6 0 000 12zM12 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm0 16a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm10-6a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5 12a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zm13.657-6.657a1 1 0 010 1.414l-.707.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM6.464 17.536a1 1 0 010 1.414l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 0zm12.728 0a1 1 0 01-1.414 1.414l-.707-.707a1 1 0 011.414-1.414l.707.707zM6.464 6.464A1 1 0 015.05 5.05l.707-.707a1 1 0 111.414 1.414l-.707.707z"/>
+                        </svg>
+                        <svg id="theme-moon" class="h-6 w-6" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M17.293 13.293A8.001 8.001 0 016.707 2.707 8 8 0 1017.293 13.293z"/>
+                        </svg>
+                    </button>
                 </div>
-                <div class="md:hidden">
-                    <button id="menu-button" class="text-charcoal focus:outline-none" aria-label="Toggle menu" aria-expanded="false">
+                <div class="flex items-center md:hidden space-x-4">
+                    <button id="theme-toggle-mobile" class="text-charcoal dark:text-platinum focus:outline-none" aria-label="Toggle dark mode">
+                        <svg id="theme-sun-mobile" class="h-6 w-6 hidden" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M12 18a6 6 0 100-12 6 6 0 000 12zM12 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm0 16a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm10-6a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5 12a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zm13.657-6.657a1 1 0 010 1.414l-.707.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM6.464 17.536a1 1 0 010 1.414l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 0zm12.728 0a1 1 0 01-1.414 1.414l-.707-.707a1 1 0 011.414-1.414l.707.707zM6.464 6.464A1 1 0 015.05 5.05l.707-.707a1 1 0 111.414 1.414l-.707.707z"/>
+                        </svg>
+                        <svg id="theme-moon-mobile" class="h-6 w-6" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M17.293 13.293A8.001 8.001 0 016.707 2.707 8 8 0 1017.293 13.293z"/>
+                        </svg>
+                    </button>
+                    <button id="menu-button" class="text-charcoal focus:outline-none md:hidden" aria-label="Toggle menu" aria-expanded="false">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                         </svg>
@@ -1530,6 +1578,42 @@
     </footer>
 
     <script>
+        const toggleTheme = (btn, sunIcon, moonIcon) => {
+            document.documentElement.classList.toggle('dark');
+            const isDark = document.documentElement.classList.contains('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            if (sunIcon && moonIcon) {
+                sunIcon.classList.toggle('hidden', !isDark);
+                moonIcon.classList.toggle('hidden', isDark);
+            }
+        };
+
+        const initTheme = (btn, sunIcon, moonIcon) => {
+            const stored = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (stored === 'dark' || (!stored && prefersDark)) {
+                document.documentElement.classList.add('dark');
+                if (sunIcon && moonIcon) {
+                    sunIcon.classList.remove('hidden');
+                    moonIcon.classList.add('hidden');
+                }
+            }
+            if (btn) {
+                btn.addEventListener('click', () => toggleTheme(btn, sunIcon, moonIcon));
+            }
+        };
+
+        initTheme(
+            document.getElementById('theme-toggle'),
+            document.getElementById('theme-sun'),
+            document.getElementById('theme-moon')
+        );
+        initTheme(
+            document.getElementById('theme-toggle-mobile'),
+            document.getElementById('theme-sun-mobile'),
+            document.getElementById('theme-moon-mobile')
+        );
+
         // Mobile menu toggle
         const menuButton = document.getElementById('menu-button');
         const mobileMenu = document.getElementById('mobile-menu');


### PR DESCRIPTION
## Summary
- enhance color palette and allow dark mode via Tailwind class
- provide dark mode button in nav for desktop and mobile
- adjust input and text colors for readability
- persist theme choice with `localStorage`

## Testing
- `npm test`
- `npm run build`
- `npm run start` *(manual exit)*

------
https://chatgpt.com/codex/tasks/task_b_6879c70d4cd48327bf718557ede44a5c