### PR TITLE
Fix dark mode text contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,20 @@
         html.dark .text-darkgray, html.dark [class*="text-darkgray"] {
             color: #CCCCCC !important;
         }
+
+        /* Override inline styles for dark mode */
+        html.dark [style*="color: #333"],
+        html.dark [style*="color:#333"] {
+            color: #E5E5E5 !important;
+        }
+        html.dark [style*="color: #555"],
+        html.dark [style*="color:#555"] {
+            color: #CCCCCC !important;
+        }
+        html.dark [style*="background-color: white"],
+        html.dark [style*="background-color:white"] {
+            background-color: #333333 !important;
+        }
         
         .bg-platinum, [class*="bg-platinum"] {
             background-color: #E5E5E5 !important;


### PR DESCRIPTION
## Summary
- ensure text with inline color styles remains legible in dark mode

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6879cc5fa4048327bbcae0bce6c18ac9