### PR TITLE
Fix dark mode for about section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -166,9 +166,14 @@
             background-color: #333333 !important;
         }
         
-        .bg-platinum, [class*="bg-platinum"] {
-            background-color: #E5E5E5 !important;
-        }
+.bg-platinum, [class*="bg-platinum"] {
+    background-color: #E5E5E5 !important;
+}
+
+html.dark .bg-platinum,
+html.dark [class*="bg-platinum"] {
+    background-color: #2b2b2b !important;
+}
 
         .text-platinum, [class*="text-platinum"] {
             color: #E5E5E5 !important;


### PR DESCRIPTION
## Summary
- fix about section background in dark mode

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687ac6513ad88327b6e9ed2f22c31b9a