### PR TITLE
Fix dark mode calendar styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -341,6 +341,10 @@ html.dark [class*="bg-platinum"] {
             transition: background-color 0.2s ease;
             border-radius: 2px;
         }
+        html.dark .calendar-day:not(.empty) {
+            background-color: #2b2b2b;
+            border-color: #666666;
+        }
         .calendar-day span {
             display: inline-block;
             pointer-events: none;


### PR DESCRIPTION
## Summary
- ensure calendar days use dark theme background when dark mode is active

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687b410c254483279534afa2003a74e4