### PR TITLE
Fix calendar colors by removing static day markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,43 +887,8 @@
                                     <div class="text-center text-xs md:text-sm font-medium text-darkgray py-1 md:py-2 bg-lightgray">S</div>
                                 </div>
                             </div>
-                            <!-- Calendar days grid -->
-                            <div id="calendar-days" class="grid grid-cols-7 gap-1">
-                                <!-- Sample calendar days for immediate display -->
-                                <div class="calendar-day empty"></div>
-                                <div class="calendar-day empty"></div>
-                                <div class="calendar-day empty"></div>
-                                <div class="calendar-day">1</div>
-                                <div class="calendar-day">2</div>
-                                <div class="calendar-day">3</div>
-                                <div class="calendar-day">4</div>
-                                <div class="calendar-day">5</div>
-                                <div class="calendar-day">6</div>
-                                <div class="calendar-day">7</div>
-                                <div class="calendar-day">8</div>
-                                <div class="calendar-day">9</div>
-                                <div class="calendar-day">10</div>
-                                <div class="calendar-day">11</div>
-                                <div class="calendar-day">12</div>
-                                <div class="calendar-day">13</div>
-                                <div class="calendar-day">14</div>
-                                <div class="calendar-day selected">15</div>
-                                <div class="calendar-day">16</div>
-                                <div class="calendar-day">17</div>
-                                <div class="calendar-day">18</div>
-                                <div class="calendar-day">19</div>
-                                <div class="calendar-day">20</div>
-                                <div class="calendar-day">21</div>
-                                <div class="calendar-day">22</div>
-                                <div class="calendar-day">23</div>
-                                <div class="calendar-day">24</div>
-                                <div class="calendar-day">25</div>
-                                <div class="calendar-day">26</div>
-                                <div class="calendar-day">27</div>
-                                <div class="calendar-day">28</div>
-                                <div class="calendar-day">29</div>
-                                <div class="calendar-day">30</div>
-                            </div>
+                            <!-- Calendar days grid populated by JavaScript -->
+                            <div id="calendar-days" class="grid grid-cols-7 gap-1"></div>
                         </div>
                         
                         <div id="time-slots" class="hidden mt-5">


### PR DESCRIPTION
## Summary
- remove sample calendar days from `index.html`

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687b4fbc34ac83279ca7a6c72b847453