### PR TITLE
Fix calendar aspect ratio

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -341,7 +341,8 @@ html.dark [class*="bg-platinum"] {
         .calendar-day {
             position: relative;
             width: 100%;
-            height: 40px;
+            aspect-ratio: 1 / 1;
+            min-height: 40px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -394,9 +395,13 @@ html.dark [class*="bg-platinum"] {
         }
         #calendar-days {
             display: grid;
-            grid-template-columns: repeat(7, 1fr);
+            grid-template-columns: repeat(7, minmax(0, 1fr));
+            grid-auto-rows: 1fr;
             gap: 4px;
             width: 100%;
+            max-width: 350px;
+            margin-left: auto;
+            margin-right: auto;
             box-sizing: border-box;
         }
         .calendar-header .grid-cols-7 {

--- a/styles.css
+++ b/styles.css
@@ -342,7 +342,8 @@ html.dark [class*="bg-platinum"] {
         .calendar-day {
             position: relative;
             width: 100%;
-            height: 40px;
+            aspect-ratio: 1 / 1;
+            min-height: 40px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -395,9 +396,13 @@ html.dark [class*="bg-platinum"] {
         }
         #calendar-days {
             display: grid;
-            grid-template-columns: repeat(7, 1fr);
+            grid-template-columns: repeat(7, minmax(0, 1fr));
+            grid-auto-rows: 1fr;
             gap: 4px;
             width: 100%;
+            max-width: 350px;
+            margin-left: auto;
+            margin-right: auto;
             box-sizing: border-box;
         }
         .calendar-header .grid-cols-7 {


### PR DESCRIPTION
## Summary
- maintain square calendar cells to avoid stretching
- center the calendar grid and limit its width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c60076d3083278b36fb4a4b5ca194