### PR TITLE
Remove unsafe-inline from CSP

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ app.use(express.static(staticDir, {
     res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
     res.setHeader(
       'Content-Security-Policy',
-      "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com"
+      "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com"
     );
   },
 }));


### PR DESCRIPTION
## Summary
- drop `unsafe-inline` from the `style-src` directive in `server.js`
- run unit tests and production build

## Testing
- `npm test`
- `npm run build`
- `curl -I http://localhost:3000/index.html`

------
https://chatgpt.com/codex/tasks/task_b_687c6e511370832782a354b7dc13dfd1