### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/e2e/site.pw.js
+++ b/e2e/site.pw.js
@@ -1,0 +1,47 @@
+const { test, expect } = require('playwright/test');
+
+const stubExternal = async page => {
+  await page.route('https://fonts.googleapis.com/**', route => route.fulfill({ status: 200, body: '' }));
+  await page.route('https://fonts.gstatic.com/**', route => route.fulfill({ status: 200, body: '' }));
+  await page.route('https://keystonenotarygroup.com/**', route => route.fulfill({ status: 200, body: '' }));
+};
+
+test.beforeEach(async ({ page }) => {
+  await stubExternal(page);
+  await page.goto('/');
+});
+
+test('client portal modal open and close', async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  await page.getByRole('button', { name: /client portal login/i }).click();
+  const modal = page.locator('#client-portal-modal');
+  await expect(modal).toBeVisible();
+  await page.getByRole('button', { name: /close modal/i }).click();
+  await expect(modal).toBeHidden();
+});
+
+test('calendar date and time selection', async ({ page }) => {
+  await page.setViewportSize({ width: 768, height: 1024 });
+  const day = page.locator('.calendar-day:not(.disabled):not(.empty)').first();
+  await day.click();
+  await page.waitForSelector('#time-slots', { state: 'visible' });
+  const details = page.locator('#appointment-details');
+  await expect(details).not.toHaveText(/No date/);
+});
+
+test('FAQ accordion toggle', async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  const question = page.locator('.faq-question').first();
+  const answer = question.locator('xpath=following-sibling::*[1]');
+  await question.click();
+  await expect(answer).toBeVisible();
+  await question.click();
+  await expect(answer).toBeHidden();
+});
+
+test('theme toggle persists across reloads', async ({ page }) => {
+  await page.getByRole('button', { name: /toggle dark mode/i }).click();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  await page.reload();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
+        "@playwright/test": "^1.41.2",
         "esbuild": "^0.19.11",
         "eslint": "^8.57.0",
+        "playwright": "^1.41.2",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.4"
       }
@@ -877,6 +879,23 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+      "deprecated": "Please update to the latest version of Playwright to test up-to-date browsers.",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.41.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@sindresorhus/slugify": {
@@ -3630,6 +3649,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.41.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node build.js",
     "lint": "eslint .",
-    "test": "node --test",
+    "test": "node --test && playwright test",
     "start": "node server.js"
   },
   "keywords": [],
@@ -17,10 +17,12 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
+    "@11ty/eleventy": "^2.0.1",
+    "@playwright/test": "^1.41.2",
     "esbuild": "^0.19.11",
     "eslint": "^8.57.0",
+    "playwright": "^1.41.2",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.4"
-    ,"@11ty/eleventy": "^2.0.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,26 @@
+const { devices } = require('@playwright/test');
+
+const port = process.env.PORT || 3000;
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+module.exports = {
+  testDir: './e2e',
+  testMatch: '**/*.pw.js',
+  timeout: 30000,
+  retries: 0,
+  webServer: {
+    command: 'node server.js',
+    port,
+    reuseExistingServer: true
+  },
+  use: {
+    baseURL: `http://localhost:${port}`,
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true
+  },
+  projects: [
+    { name: 'desktop', use: { browserName: 'chromium', ...devices['Desktop Chrome'] } },
+    { name: 'mobile', use: { browserName: 'chromium', ...devices['Pixel 5'] } }
+  ]
+};


### PR DESCRIPTION
## Summary
- add Playwright and config
- write E2E tests covering portal modal, calendar, FAQ accordion and theme toggle
- update test script to run Playwright

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c6f1ab9f4832789552ed34e710ece