### PR TITLE
Fix build step on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project serves a static marketing site powered by an Express server. The bu
 
 ## Development
 
-Install dependencies and run the server:
+Install dependencies and run the server. The build step runs automatically:
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node build.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
     "test": "node --test && playwright test",
+    "prestart": "npm run build",
     "start": "node server.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- automatically build before running the dev server
- clarify README that the build step runs automatically

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687ded8a9cc8832790865809bc535912