### PR TITLE
Improve theme responsiveness and clean up verification logic

### DIFF
--- a/src/document-verification.js
+++ b/src/document-verification.js
@@ -162,8 +162,6 @@ export function initDocumentVerification() {
     let isValid = true;
     const issues = [];
 
-    const resultStatusContainer = document.getElementById('result-status-container');
-
     if (fileName.includes('power') || fileName.includes('attorney')) {
       documentCategory = 'Power of Attorney';
     } else if (fileName.includes('deed') || fileName.includes('title') || fileName.includes('property')) {

--- a/theme.js
+++ b/theme.js
@@ -26,8 +26,8 @@ export function initTheme() {
   };
 
   const stored = localStorage.getItem('theme');
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const startDark = stored === 'dark' || (!stored && prefersDark);
+  const colorSchemeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+  const startDark = stored === 'dark' || (!stored && colorSchemeMedia.matches);
   if (startDark) {
     document.documentElement.classList.add('dark');
     if (sunIcon && moonIcon) {
@@ -41,6 +41,21 @@ export function initTheme() {
     btn.setAttribute('aria-pressed', 'false');
   }
   setThemeAttributes(startDark);
+
+  if (!stored) {
+    colorSchemeMedia.addEventListener('change', (e) => {
+      const isDark = e.matches;
+      document.documentElement.classList.toggle('dark', isDark);
+      if (sunIcon && moonIcon) {
+        sunIcon.classList.toggle('hidden', !isDark);
+        moonIcon.classList.toggle('hidden', isDark);
+      }
+      if (btn) {
+        btn.setAttribute('aria-pressed', String(isDark));
+      }
+      setThemeAttributes(isDark);
+    });
+  }
 
   if (btn) {
     btn.addEventListener('click', toggleTheme);


### PR DESCRIPTION
## Summary
- simplify document verification logic
- add system color scheme listener so theme follows OS preference

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687df0ad7ae48327814056adfd004e6e