### PR TITLE
Fix mobile spacing in services section

### DIFF
--- a/templates/_includes/services.html
+++ b/templates/_includes/services.html
@@ -1,12 +1,12 @@
-    <section id="services" class="py-16 md:py-20 bg-white pb-28">
+    <section id="services" class="relative py-16 md:py-20 bg-white z-0 overflow-visible">
         <div class="container mx-auto px-4 md:px-6">
             <div class="text-center mb-12 md:mb-16">
                 <h2 class="text-2xl md:text-3xl font-light text-charcoal mb-4">Our Notary Services</h2>
                 <div class="w-24 h-1 bg-charcoal mx-auto"></div>
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-12 gap-x-8 md:gap-y-16 md:gap-x-10">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-12 gap-x-6 md:gap-y-16 md:gap-x-10 px-4 md:px-6">
                 <!-- Service 1 -->
-                <div class="service-card bg-lightgray p-6 md:p-8 rounded-sm shadow-sm transition-all duration-300 hover-lift flex flex-col h-full min-h-[320px]">
+                <div class="bg-lightgray rounded-lg shadow-md p-6 flex flex-col justify-between min-h-[340px]">
                     <div class="mb-4 md:mb-6">
                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 md:h-12 md:w-12 text-charcoal" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -25,7 +25,7 @@
                 </div>
                 
                 <!-- Service 2 -->
-                <div class="service-card bg-lightgray p-6 md:p-8 rounded-sm shadow-sm transition-all duration-300 hover-lift flex flex-col h-full min-h-[320px]">
+                <div class="bg-lightgray rounded-lg shadow-md p-6 flex flex-col justify-between min-h-[340px]">
                     <div class="mb-4 md:mb-6">
                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 md:h-12 md:w-12 text-charcoal" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2" />
@@ -44,7 +44,7 @@
                 </div>
                 
                 <!-- Service 3 -->
-                <div class="service-card bg-lightgray p-6 md:p-8 rounded-sm shadow-sm transition-all duration-300 hover-lift flex flex-col h-full min-h-[320px]">
+                <div class="bg-lightgray rounded-lg shadow-md p-6 flex flex-col justify-between min-h-[340px]">
                     <div class="mb-4 md:mb-6">
                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 md:h-12 md:w-12 text-charcoal" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z" />
@@ -158,4 +158,4 @@
             </div>
         </div>
     </section>
-    <div class="h-16 md:h-0"></div>
+    <div class="h-24 md:h-0"></div>


### PR DESCRIPTION
## Summary
- update layout styles for services section to prevent overlap and inconsistent sizing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687e746820b88327b911f7b9d78f3023