### PR TITLE
Add referrer and permissions security headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,9 @@ app.use(express.static(staticDir, {
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+    // Limit referrer and feature permissions for improved privacy
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Permissions-Policy', 'camera=(), microphone=()');
     res.setHeader(
       'Content-Security-Policy',
       "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com"

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -18,6 +18,8 @@ test('static headers', async () => {
   assert.equal(res.status, 200);
   assert.ok(res.headers.get('cache-control'));
   assert.ok(res.headers.get('content-security-policy'));
+  assert.ok(res.headers.get('referrer-policy'));
+  assert.ok(res.headers.get('permissions-policy'));
 });
 
 test('forms expose live regions', async () => {


### PR DESCRIPTION
## Summary
- secure Express response headers: `Referrer-Policy` and `Permissions-Policy`
- verify new headers in server tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6881dc4863c48327a1401d683e51fc4f