### PR TITLE
Implement 404 fallback route

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,6 +24,9 @@ app.use(express.static(staticDir, {
     );
   },
 }));
+app.use((req, res) => {
+  res.status(404).sendFile(path.join(staticDir, 'index.html'));
+});
 if (require.main === module) {
   app.listen(PORT);
 }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -38,3 +38,9 @@ test('no inline styles remain', async () => {
   const html = await fs.promises.readFile('index.html', 'utf8');
   assert.equal(html.includes('style="'), false);
 });
+
+test('returns 404 for unknown routes', async () => {
+  const { port } = server.address();
+  const res = await fetch(`http://localhost:${port}/missing-page`);
+  assert.equal(res.status, 404);
+});


### PR DESCRIPTION
## Summary
- serve `index.html` for all unmatched routes so the app gracefully handles unknown URLs
- verify that the server responds with `404` for invalid paths

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6881e68c67b083278ff0904940c4e65a