### PR TITLE
Fix GSAP animation in Services section

### DIFF
--- a/templates/_includes/services.html
+++ b/templates/_includes/services.html
@@ -153,6 +153,10 @@
         </div>
     </section>
 
+<!-- Add GSAP & ScrollTrigger via CDN -->
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js"></script>
+
 <!-- Animate service cards on scroll -->
 <script>
   window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- include GSAP and ScrollTrigger CDN scripts in `services.html` so animations run

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6881f2bc13f4832797b854067567e275