### PR TITLE
Restore service section animations

### DIFF
--- a/src/services-animation.js
+++ b/src/services-animation.js
@@ -1,19 +1,19 @@
 export function initServiceAnimations() {
   window.addEventListener('load', () => {
-    if (window.gsap && window.ScrollTrigger) {
+    if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
       gsap.registerPlugin(ScrollTrigger);
       gsap.utils.toArray('.service-card').forEach((card, i) => {
         gsap.from(card, {
           scrollTrigger: {
             trigger: card,
             start: 'top 90%',
-            toggleActions: 'play none none none'
+            toggleActions: 'play none none none',
           },
           y: 40,
           opacity: 0,
           duration: 0.8,
           delay: i * 0.15,
-          ease: 'power3.out'
+          ease: 'power3.out',
         });
       });
     }


### PR DESCRIPTION
## Summary
- ensure ScrollTrigger loads with GSAP before main bundle
- initialize animations only after GSAP is available

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6881f7384c408327938fd3a3e665aa10