### PR TITLE
Fix dark mode toggle and card stacking

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,8 +6,6 @@ import { initDocumentVerification } from './src/document-verification.js';
 import { initHeroAnimations } from './src/hero-animation.js';
 import { initScrollAnimations } from './src/scrollAnimations.js';
 import { initServiceCardStack } from './src/service-card-stack.js';
-initTheme();
-initHeroAnimations();
 
 // Mobile menu toggle
 const menuButton = document.getElementById('menu-button');
@@ -244,6 +242,8 @@ document.querySelectorAll('.faq-question').forEach((question) => {
 
 // Initialize site features
 document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+  initHeroAnimations();
   initCalendar();
   initClientPortal();
   initDocumentVerification();

--- a/src/service-card-stack.js
+++ b/src/service-card-stack.js
@@ -11,7 +11,9 @@ export function initServiceCardStack() {
   ).matches;
   if (prefersReducedMotion) return;
 
-  const cards = document.querySelectorAll('.stacked-services .service-card');
+  const container = document.querySelector('.stacked-services');
+  if (!container) return;
+  const cards = container.querySelectorAll('.service-card');
   if (!cards.length) return;
 
   const rootFont = parseFloat(
@@ -19,6 +21,7 @@ export function initServiceCardStack() {
   );
   const step = 2.5 * rootFont; // 2.5rem offset for visible stacking
 
+  container.classList.add('relative');
   cards.forEach((card, index) => {
     card.style.position = 'sticky';
     card.style.setProperty('top', `${index * step}px`);

--- a/templates/_includes/services.html
+++ b/templates/_includes/services.html
@@ -5,7 +5,7 @@
                 <h2 class="text-2xl md:text-3xl font-light text-charcoal mb-4">Our Notary Services</h2>
                 <div class="w-24 h-1 bg-charcoal mx-auto"></div>
             </div>
-            <div class="stacked-services grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 md:gap-10">
+            <div class="stacked-services space-y-8">
                 <!-- Service 1 -->
                 <div class="service-card transition-opacity duration-700 ease-in bg-lightgray p-6 md:p-8 rounded-sm shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg hover:ring-1 hover:ring-black/10 flex flex-col h-full" data-animate="animate-slide-up">
                     <div class="mb-4 md:mb-6">


### PR DESCRIPTION
## Summary
- initialize theme and hero animations after DOM loads so toggle works
- switch services list to vertical stacking
- support card stacking with sticky positioning

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68822c8fca9c83279602c8ce3587a70d